### PR TITLE
fix(update): fall back to beta channel when checking for updates

### DIFF
--- a/src/Controller/Admin/SystemUpdateController.php
+++ b/src/Controller/Admin/SystemUpdateController.php
@@ -180,7 +180,10 @@ final class SystemUpdateController
         try {
             $result = $this->updater->check();
             if (!empty($result['error'])) {
-                $this->session->flashError('Unable to reach update server. ' . ($result['message'] ?? 'Check your internet connection and try again.'));
+                $errorMessage = $result['error'] === 'connection_failed'
+                    ? 'Unable to reach update server. ' . ($result['message'] ?? 'Check your internet connection and try again.')
+                    : 'Update server returned an unexpected response. Please try again later.';
+                $this->session->flashError($errorMessage);
             } elseif ($result['available']) {
                 $cacheFile = dirname(__DIR__, 3) . '/storage/cache/update_check.json';
                 @file_put_contents($cacheFile, json_encode($result));

--- a/src/Update/UpdateService.php
+++ b/src/Update/UpdateService.php
@@ -146,23 +146,8 @@ EOT;
                 return ['available' => false, 'error' => 'invalid_response'];
             }
 
-            $latestVersion = null;
-            $downloadUrl = null;
-            $changelog = null;
-            $checksum = null;
-
-            $channels = $data['channels'] ?? null;
-            if (is_array($channels) && isset($channels['stable']) && is_array($channels['stable'])) {
-                $stable = $channels['stable'];
-                $latestVersion = is_string($stable['latest_version_name'] ?? null) ? $stable['latest_version_name'] : null;
-                $downloadUrl = is_string($stable['download_url'] ?? null) ? $stable['download_url'] : null;
-                $changelog = is_string($stable['changelog'] ?? null) ? $stable['changelog'] : null;
-                $checksum = is_string($stable['checksum_sha256'] ?? null) ? $stable['checksum_sha256'] : null;
-            } else {
-                $latestVersion = is_string($data['version'] ?? null) ? $data['version'] : null;
-                $downloadUrl = is_string($data['download_url'] ?? null) ? $data['download_url'] : null;
-                $changelog = is_string($data['changelog'] ?? null) ? $data['changelog'] : null;
-            }
+            ['version' => $latestVersion, 'url' => $downloadUrl, 'changelog' => $changelog, 'checksum' => $checksum]
+                = $this->resolveManifestFields($data);
 
             if ($latestVersion === null) {
                 return ['available' => false, 'error' => 'invalid_response'];
@@ -191,6 +176,48 @@ EOT;
         } catch (\Throwable $e) {
             return ['available' => false, 'error' => 'connection_failed', 'message' => $e->getMessage()];
         }
+    }
+
+    /**
+     * Extracts the latest-version fields from a decoded manifest response.
+     *
+     * Prefers the 'stable' channel but falls back to 'beta' - pre-1.0 releases
+     * are only ever published to the beta channel, so requiring 'stable' made
+     * check() fail with invalid_response until a stable channel exists on the
+     * update server. Falls back further to top-level fields for manifests
+     * published without a 'channels' section at all.
+     *
+     * @param array<mixed, mixed> $data Decoded manifest JSON.
+     * @return array{version: string|null, url: string|null, changelog: string|null, checksum: string|null}
+     */
+    private function resolveManifestFields(array $data): array
+    {
+        $channels = $data['channels'] ?? null;
+        $channel = null;
+        if (is_array($channels)) {
+            foreach (['stable', 'beta'] as $channelName) {
+                if (isset($channels[$channelName]) && is_array($channels[$channelName])) {
+                    $channel = $channels[$channelName];
+                    break;
+                }
+            }
+        }
+
+        if ($channel !== null) {
+            return [
+                'version'   => is_string($channel['latest_version_name'] ?? null) ? $channel['latest_version_name'] : null,
+                'url'       => is_string($channel['download_url'] ?? null) ? $channel['download_url'] : null,
+                'changelog' => is_string($channel['changelog'] ?? null) ? $channel['changelog'] : null,
+                'checksum'  => is_string($channel['checksum_sha256'] ?? null) ? $channel['checksum_sha256'] : null,
+            ];
+        }
+
+        return [
+            'version'   => is_string($data['version'] ?? null) ? $data['version'] : null,
+            'url'       => is_string($data['download_url'] ?? null) ? $data['download_url'] : null,
+            'changelog' => is_string($data['changelog'] ?? null) ? $data['changelog'] : null,
+            'checksum'  => null,
+        ];
     }
 
     /**

--- a/tests/Unit/UpdateServiceTest.php
+++ b/tests/Unit/UpdateServiceTest.php
@@ -327,6 +327,66 @@ class UpdateServiceTest extends TestCase
         }
     }
 
+    /** @param array<mixed, mixed> $data */
+    private function resolveManifestFields(array $data): array
+    {
+        $method = new \ReflectionMethod(UpdateService::class, 'resolveManifestFields');
+        /** @var array<string, mixed> $result */
+        $result = $method->invoke($this->createUpdateService(), $data);
+        return $result;
+    }
+
+    public function testResolveManifestFieldsPrefersStableChannel(): void
+    {
+        $fields = $this->resolveManifestFields([
+            'channels' => [
+                'stable' => ['latest_version_name' => '1.0.0', 'download_url' => 'https://example.com/1.0.0.zip'],
+                'beta'   => ['latest_version_name' => '1.1.0-beta', 'download_url' => 'https://example.com/1.1.0-beta.zip'],
+            ],
+        ]);
+
+        $this->assertSame('1.0.0', $fields['version']);
+        $this->assertSame('https://example.com/1.0.0.zip', $fields['url']);
+    }
+
+    public function testResolveManifestFieldsFallsBackToBetaWhenStableIsAbsent(): void
+    {
+        $fields = $this->resolveManifestFields([
+            'channels' => [
+                'beta' => [
+                    'latest_version_name' => '0.2.0',
+                    'download_url' => 'https://example.com/0.2.0.zip',
+                    'changelog' => 'Some changes',
+                    'checksum_sha256' => 'abc123',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('0.2.0', $fields['version']);
+        $this->assertSame('https://example.com/0.2.0.zip', $fields['url']);
+        $this->assertSame('Some changes', $fields['changelog']);
+        $this->assertSame('abc123', $fields['checksum']);
+    }
+
+    public function testResolveManifestFieldsFallsBackToTopLevelWhenNoChannelsPresent(): void
+    {
+        $fields = $this->resolveManifestFields([
+            'version' => '2.0.0',
+            'download_url' => 'https://example.com/2.0.0.zip',
+        ]);
+
+        $this->assertSame('2.0.0', $fields['version']);
+        $this->assertSame('https://example.com/2.0.0.zip', $fields['url']);
+    }
+
+    public function testResolveManifestFieldsReturnsNullVersionWhenNothingMatches(): void
+    {
+        $fields = $this->resolveManifestFields(['unrelated' => 'data']);
+
+        $this->assertNull($fields['version']);
+        $this->assertNull($fields['url']);
+    }
+
     public function testPurgeOldLogsIsANoOpWhenDirectoryIsMissing(): void
     {
         $updater = $this->createUpdateService();


### PR DESCRIPTION
## Description
UpdateService::check() only looked at the manifest's 'stable' channel, but this pre-1.0 app only ever publishes to 'beta' - every check() call failed with invalid_response, surfaced to the admin as a misleading 'Unable to reach update server' message even though the server responded fine.

Extracted the channel-selection logic into resolveManifestFields() (prefers stable, falls back to beta, then to top-level fields) and split the controller's error message so a genuine connection failure and an unexpected/unparseable response no longer share the same wording.

Live-verified against the real update.ownpay.org manifest: check() now correctly resolves the beta channel's 0.2.0 entry instead of failing.
Fixes # (issue)

## Type of Change
Please check options that are relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## 🎨 Design / UI Changes
*(If applicable, please attach screenshots or screen recordings showcasing the visual differences)*

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- [ ] Automated Unit Tests (`vendor/bin/phpunit`)
- [ ] Static Analysis Check (`vendor/bin/phpstan analyse`)
- [ ] Manual verification in local environment

**Test Configuration**:
* OwnPay Version:
* PHP Version:
* Database:
* Environment:

## Checklist:
- [ ] My PR targets the **`dev` branch** and not the `main` branch.
- [ ] My code follows the [PSR-12 coding standards](https://github.com/own-pay/OwnPay/blob/main/CONTRIBUTING.md).
- [ ] I have declared `declare(strict_types=1);` at the top of all new PHP files.
- [ ] I have resolved dependencies via the DI container where applicable.
- [ ] I have scoped brand-specific reads via `TenantScope` and writes via `BrandContext::getWriteMerchantId()`.
- [ ] All new database tables/columns use the `op_` prefix and follow the column naming conventions.
- [ ] My forms use the canonical `_csrf_token` retrieved via `\OwnPay\Security\SecurityHelpers::csrfToken()`.
- [ ] I have performed a self-review of my code and run linting checks (`php -l`).
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.

## ⚖️ License
- [ ] I agree that my contributions will be licensed under the **AGPL-3.0 License**.