### PR TITLE
security: fix CodeQL js/xss-through-dom alerts using URL and searchPa…

### DIFF
--- a/public/assets/js/admin.js
+++ b/public/assets/js/admin.js
@@ -899,7 +899,12 @@
         var nameEl = document.getElementById("delete-item-name");
         var modal = document.getElementById("confirm-delete-modal");
         if (form && nameEl && modal && typeof action === "string" && action.startsWith("/") && !hasUnsafeUrlScheme(action)) {
-            form.action = action;
+            try {
+                // Enforce strict pathname formatting to prevent scheme/protocol injection XSS.
+                form.action = new URL(action, window.location.origin).pathname;
+            } catch {
+                return;
+            }
             nameEl.textContent = itemName;
             modal.hidden = false;
         }

--- a/public/assets/js/checkout-status.js
+++ b/public/assets/js/checkout-status.js
@@ -37,19 +37,23 @@ document.addEventListener("DOMContentLoaded", function() {
         var paymentId = wrapper.getAttribute("data-payment-id");
         var status = wrapper.getAttribute("data-status");
 
-        // Refuses javascript:/data:/vbscript: (and any other non-http(s)) URL schemes. The server
-        // already rejects non-http(s) redirect_url values at intent creation, but this stays the
-        // last line of defense before the value drives href/location.href navigation targets.
-        var hasSafeUrlScheme = function (url) {
-            if (!url) { return false; }
-            var schemeMatch = url.trim().match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
-            return !schemeMatch || schemeMatch[1].toLowerCase() === "http" || schemeMatch[1].toLowerCase() === "https";
-        };
+        var finalUrl = "";
+        try {
+            if (redirectUrl) {
+                // Parse and resolve against origin to handle both relative and absolute URLs.
+                var parsedUrl = new URL(redirectUrl, window.location.origin);
+                // Enforce safe URL schemes (http: and https: only).
+                if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+                    parsedUrl.searchParams.set("payment_id", paymentId || "");
+                    parsedUrl.searchParams.set("status", status || "");
+                    finalUrl = parsedUrl.href;
+                }
+            }
+        } catch {
+            // Invalid URL - fallback to empty (fail closed)
+        }
 
-        if (redirectUrl && hasSafeUrlScheme(redirectUrl)) {
-            // Construct target URL with query parameters
-            var separator = redirectUrl.indexOf("?") !== -1 ? "&" : "?";
-            var finalUrl = redirectUrl + separator + "payment_id=" + encodeURIComponent(paymentId) + "&status=" + encodeURIComponent(status);
+        if (finalUrl !== "") {
 
             // Update all return/merchant links on the page for instant access
             var returnBtns = document.querySelectorAll('a[href="/"], .st-btn');

--- a/public/assets/js/checkout.js
+++ b/public/assets/js/checkout.js
@@ -76,6 +76,12 @@
     if (typeof basePath !== "string" || !basePath.startsWith("/")) {
         basePath = "/checkout/" + (cfg.txnRef || "");
     }
+    try {
+        // Extract the pathname strictly (e.g. /checkout/123) to prevent scheme/protocol injection XSS.
+        basePath = new URL(basePath, window.location.origin).pathname;
+    } catch {
+        basePath = "/checkout/" + (cfg.txnRef || "");
+    }
 
     // ---------- TIMER ----------
     var TIMER_URGENCY_THRESHOLD_SEC = 60; // Show urgent style when less than 60 seconds remain


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change
Please check options that are relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## 🎨 Design / UI Changes
*(If applicable, please attach screenshots or screen recordings showcasing the visual differences)*

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- [x] Automated Unit Tests (`vendor/bin/phpunit`)
- [x] Static Analysis Check (`vendor/bin/phpstan analyse`)
- [x] Manual verification in local environment

**Test Configuration**:
* OwnPay Version: 0.2.1
* PHP Version: 8.3
* Database:
* Environment:

## Checklist:
- [] My PR targets the **`dev` branch** and not the `main` branch.
- [ ] My code follows the [PSR-12 coding standards](https://github.com/own-pay/OwnPay/blob/main/CONTRIBUTING.md).
- [ ] I have declared `declare(strict_types=1);` at the top of all new PHP files.
- [ ] I have resolved dependencies via the DI container where applicable.
- [ ] I have scoped brand-specific reads via `TenantScope` and writes via `BrandContext::getWriteMerchantId()`.
- [ ] All new database tables/columns use the `op_` prefix and follow the column naming conventions.
- [ ] My forms use the canonical `_csrf_token` retrieved via `\OwnPay\Security\SecurityHelpers::csrfToken()`.
- [ ] I have performed a self-review of my code and run linting checks (`php -l`).
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.

## ⚖️ License
- [x] I agree that my contributions will be licensed under the **AGPL-3.0 License**.