### PR TITLE
fix: Resolve 30 open issues (#38-#80, excluding #99-#116)

### DIFF
--- a/config/routes/web.php
+++ b/config/routes/web.php
@@ -127,6 +127,8 @@ return static function (\OwnPay\Http\Router $router): void {
     $router->get('/admin/disputes', 'Admin\\DisputeController@index', 'admin');
     $router->get('/admin/disputes/{id}', 'Admin\\DisputeController@show', 'admin');
     $router->post('/admin/disputes/{id}/resolve', 'Admin\\DisputeController@resolve', 'admin');
+    // Open a new dispute against a transaction (issue #61 - reachable create path).
+    $router->post('/admin/disputes/create', 'Admin\\DisputeController@create', 'admin');
 
     // Payment Links
     $router->get('/admin/payment-links', 'Admin\\PaymentLinkController@index', 'admin');

--- a/config/services.php
+++ b/config/services.php
@@ -700,6 +700,14 @@ return static function (\OwnPay\Container $c): void {
                 $emailNotifier = ensureType($c->get(\OwnPay\Service\Communication\EmailNotificationService::class), \OwnPay\Service\Communication\EmailNotificationService::class);
                 $events->addAction('payment.transaction.completed', [$emailNotifier, 'onTransactionCompleted'], 20);
                 $events->addAction('refund.created', [$emailNotifier, 'onRefundCreated'], 20);
+
+                // Auto-dispatch merchant webhooks on real payment completion (issue #59).
+                // Priority 30 so the listener runs after the payment-state listeners
+                // (PaymentCompletionListener at default priority, EmailNotifier at 20)
+                // have finalized invoice/link state; the webhook payload then reflects
+                // the post-completion view the merchant expects.
+                $webhookListener = ensureType($c->get(\OwnPay\Service\Payment\WebhookAutoDispatchListener::class), \OwnPay\Service\Payment\WebhookAutoDispatchListener::class);
+                $events->addAction('payment.transaction.completed', [$webhookListener, 'onTransactionCompleted'], 30);
             });
         } catch (\Throwable) {}
     }

--- a/public/assets/css/admin.css
+++ b/public/assets/css/admin.css
@@ -2535,7 +2535,11 @@ input[type="checkbox"]:focus-visible {
   border-radius: 12px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
   padding: 16px;
-  z-index: 150;
+  /* Issue #72: raise above dropdowns (z-index 200), the notification panel
+     (z-index 300), and modal dialogs (z-index 200) so the date picker is
+     not clipped or hidden behind adjacent elements. Toasts (z-index 1000)
+     and full-screen overlays still render above the calendar when needed. */
+  z-index: 500;
   display: none;
   opacity: 0;
   visibility: hidden;

--- a/public/assets/css/admin.css
+++ b/public/assets/css/admin.css
@@ -2535,6 +2535,7 @@ input[type="checkbox"]:focus-visible {
   border-radius: 12px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
   padding: 16px;
+
   /* Issue #72: raise above dropdowns (z-index 200), the notification panel
      (z-index 300), and modal dialogs (z-index 200) so the date picker is
      not clipped or hidden behind adjacent elements. Toasts (z-index 1000)

--- a/public/assets/css/installer.css
+++ b/public/assets/css/installer.css
@@ -107,6 +107,21 @@ body {
     letter-spacing: -0.3px;
 }
 
+/* --- Logo theme visibility (issue #40) ---
+   Two <img> elements are emitted (light + dark variants) so the right logo
+   for the active theme is shown without a flash of the wrong variant on
+   first paint. Only one is ever visible; the other is hidden via these
+   rules driven by the data-theme attribute on <html>. */
+.op-logo-dark {
+    display: none;
+}
+[data-theme="dark"] .op-logo-light {
+    display: none;
+}
+[data-theme="dark"] .op-logo-dark {
+    display: inline-block;
+}
+
 .ins-name span {
     color: var(--op-text-muted);
     font-weight: 400;
@@ -798,6 +813,44 @@ body {
 
     .ins-steps {
         gap: 4px;
+    }
+
+    /* Issue #40: shrink the connector lines on small screens so the four-step
+       indicator fits without horizontal scrolling. The number circles still
+       show, giving users a clear sense of progress without overflowing the
+       viewport or producing a horizontal scrollbar. */
+    .ins-step-line {
+        width: 12px;
+    }
+
+    .ins-step {
+        padding: 4px 6px;
+    }
+
+    .ins-step-num {
+        width: 20px;
+        height: 20px;
+        font-size: 11px;
+    }
+}
+
+/* Extra-small screens (<= 360px): collapse the step indicator to just the
+   active step number to guarantee no horizontal scroll on compact phones.
+   The active step's label is shown inline so the user still knows which
+   step they are on. */
+@media (max-width: 360px) {
+    .ins-steps {
+        /* Hide all steps except the active one. */
+        gap: 0;
+    }
+    .ins-step:not(.active) {
+        display: none;
+    }
+    .ins-step.active span:not(.ins-step-num) {
+        display: inline;
+    }
+    .ins-step-line {
+        display: none;
     }
 }
 

--- a/public/assets/css/installer.css
+++ b/public/assets/css/installer.css
@@ -115,9 +115,11 @@ body {
 .op-logo-dark {
     display: none;
 }
+
 [data-theme="dark"] .op-logo-light {
     display: none;
 }
+
 [data-theme="dark"] .op-logo-dark {
     display: inline-block;
 }
@@ -843,12 +845,15 @@ body {
         /* Hide all steps except the active one. */
         gap: 0;
     }
+
     .ins-step:not(.active) {
         display: none;
     }
+
     .ins-step.active span:not(.ins-step-num) {
         display: inline;
     }
+
     .ins-step-line {
         display: none;
     }

--- a/public/assets/js/admin.js
+++ b/public/assets/js/admin.js
@@ -546,6 +546,13 @@
             return;
         }
 
+        // Issue #72: do not show "Changes saved" toast for forms that explicitly
+        // opt out (search, filter, pagination, brand-switch, tab-toggle, etc.).
+        // These forms use POST for CSRF reasons but do not modify any data, so
+        // the success toast is misleading. Forms that actually persist data do
+        // not set this attribute and continue to show the toast as before.
+        var suppressToast = form.hasAttribute("data-no-toast");
+
         var actionUrl = new URL(form.action || window.location.href, window.location.origin);
         if (actionUrl.origin !== window.location.origin) {
             return;
@@ -553,6 +560,15 @@
 
         // Exclude logout
         if (actionUrl.pathname === "/admin/logout") {
+            return;
+        }
+
+        // Issue #72: only intercept POST forms under /admin/. GET forms
+        // (search, filter, pagination) were previously intercepted and
+        // triggered the "Changes saved" toast on every interaction, which
+        // confused users. GET forms now fall through to the browser's
+        // default navigation.
+        if (form.method.toLowerCase() !== "post") {
             return;
         }
 
@@ -637,7 +653,13 @@
                         }
 
                         window.opInitPageUI();
-                        window.opShowToast("Changes saved successfully!", "success");
+                        // Issue #72: only show the success toast when the form
+                        // actually persisted data. Forms marked with data-no-toast
+                        // (search, filter, tab-toggle, etc.) skip the toast so
+                        // users are not confused into thinking a save occurred.
+                        if (!suppressToast) {
+                            window.opShowToast("Changes saved successfully!", "success");
+                        }
                     }
                 })
                 .catch(function () {

--- a/src/Controller/Admin/DisputeController.php
+++ b/src/Controller/Admin/DisputeController.php
@@ -176,6 +176,83 @@ final class DisputeController
     }
 
     /**
+     * Post handler to open a new dispute for a transaction.
+     *
+     * Surfaces the previously-unreachable {@see DisputeService::open()} code path
+     * (issue #61) so admins can create disputes from the admin panel without
+     * requiring a manual database insert. Validates that the transaction exists
+     * and belongs to the active brand before opening the dispute.
+     *
+     * @param Request $req The incoming HTTP request.
+     * @return Response The HTTP redirect response.
+     */
+    public function create(Request $req): Response
+    {
+        $this->brand->resolveFromRequest($req);
+        $mid = $this->brand->getActiveBrandId();
+
+        if ($mid === null) {
+            $this->session->flashError('Select a brand first.');
+            return Response::redirect('/admin/disputes');
+        }
+
+        $postData = $req->post();
+        if (!is_array($postData)) {
+            $postData = [];
+        }
+
+        $txnIdVal = $postData['transaction_id'] ?? '';
+        $txnId = is_numeric($txnIdVal) ? (int) $txnIdVal : 0;
+        $reasonVal = $postData['reason'] ?? '';
+        $reason = is_string($reasonVal) ? InputSanitizer::string(trim($reasonVal)) : '';
+        $amountVal = $postData['amount'] ?? '0';
+        $amount = (is_string($amountVal) || is_numeric($amountVal)) ? (string) $amountVal : '0';
+
+        if ($txnId <= 0 || $reason === '' || !is_numeric($amount)) {
+            $this->session->flashError('Transaction ID, reason, and a valid amount are required.');
+            return Response::redirect('/admin/disputes');
+        }
+
+        // Verify the transaction exists and belongs to the active brand before
+        // opening a dispute - prevents a brand admin from opening a dispute
+        // against another brand's transaction via direct ID guessing.
+        $transaction = $this->txnRepo->forTenant((int) $mid)->findScoped($txnId);
+        if ($transaction === null) {
+            $this->session->flashError('Transaction not found or does not belong to this brand.');
+            return Response::redirect('/admin/disputes');
+        }
+
+        try {
+            $this->disputeService->open((int) $mid, $txnId, $reason, $amount);
+
+            $db = $this->c->get(\OwnPay\Core\Database::class);
+            if ($db instanceof \OwnPay\Core\Database) {
+                $db->insert('op_audit_logs', [
+                    'merchant_id' => $mid,
+                    'user_id'     => $this->session->currentUser()['id'] ?? null,
+                    'action'      => 'dispute.open',
+                    'entity_type' => 'dispute',
+                    'entity_id'   => $txnId,
+                    'new_values'  => json_encode([
+                        'transaction_id' => $txnId,
+                        'reason'         => $reason,
+                        'amount'         => $amount,
+                    ]),
+                    'ip_address'  => $req->server('REMOTE_ADDR'),
+                    'user_agent'  => $req->server('HTTP_USER_AGENT'),
+                    'created_at'  => \OwnPay\Support\DateHelper::now(),
+                ]);
+            }
+
+            $this->session->flashSuccess('Dispute opened successfully.');
+        } catch (\Throwable $e) {
+            $this->session->flashError('Failed to open dispute: ' . $e->getMessage());
+        }
+
+        return Response::redirect('/admin/disputes');
+    }
+
+    /**
      * Post handler to record dispute resolution status and description.
      *
      * @param Request $req The incoming HTTP request.

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -146,6 +146,7 @@ final class SettingsController
                 'timer_enabled' => $brandSettings['timer_enabled'] ?? '0',
                 'timer_seconds' => $brandSettings['timer_seconds'] ?? '900',
                 'show_faq' => $brandSettings['show_faq'] ?? '0',
+                'auto_redirect_to_merchant' => $brandSettings['auto_redirect_to_merchant'] ?? '0',
                 'custom_css' => $brandSettings['custom_css'] ?? '',
                 'custom_js' => $brandSettings['custom_js'] ?? '',
             ];
@@ -548,6 +549,11 @@ final class SettingsController
                     $brandSettings['timer_seconds'] = is_scalar($timerSecondsVal) ? (string) $timerSecondsVal : '900';
                     
                     $brandSettings['show_faq'] = isset($data['show_faq']) && $data['show_faq'] === '1' ? '1' : '0';
+
+                    // Issue #71: auto-redirect toggle. When enabled, the success
+                    // page issues an immediate client-side redirect to the
+                    // merchant return URL instead of showing the invoice screen.
+                    $brandSettings['auto_redirect_to_merchant'] = isset($data['auto_redirect_to_merchant']) && $data['auto_redirect_to_merchant'] === '1' ? '1' : '0';
                     
                     $isSuperadmin = !empty($_SESSION['is_superadmin']);
                     if ($isSuperadmin) {
@@ -556,10 +562,18 @@ final class SettingsController
                         $customJsVal = $data['custom_js'] ?? ($brandSettings['custom_js'] ?? '');
                         $customJs = is_string($customJsVal) ? $customJsVal : '';
 
-                        $customCss = preg_replace('/expression\s*\(|behavior\s*:|javascript\s*:/i', '', $customCss);
-                        $customCss = preg_replace('/<\s*script\b[^>]*>(.*?)<\s*\/\s*script\s*>/is', '', is_string($customCss) ? $customCss : '');
+                        // Sanitize brand-supplied CSS (issue #79). Even though
+                        // only superadmins can set this field, defense-in-depth
+                        // removes the well-known CSS-borne XSS vectors so a
+                        // compromised superadmin session cannot weaponize the
+                        // checkout page against customers. JS is gated by a
+                        // CSP nonce at render time (see checkout.js), so we do
+                        // not strip content here - but we keep the audit trail
+                        // via the surrounding audit log write so every change
+                        // to custom_js is attributable.
+                        $customCss = $this->sanitizeBrandCss($customCss);
 
-                        $brandSettings['custom_css'] = is_string($customCss) ? $customCss : '';
+                        $brandSettings['custom_css'] = $customCss;
                         $brandSettings['custom_js']  = $customJs;
                     }
                     break;
@@ -1748,5 +1762,52 @@ final class SettingsController
         }
 
         return Response::redirect('/admin/settings/language');
+    }
+
+    /**
+     * Sanitizes brand-supplied custom CSS for known XSS vectors (issue #79).
+     *
+     * Brand CSS is rendered into a `<style>` element on the customer-facing
+     * checkout page, so the attack surface is CSS-borne script execution
+     * rather than HTML injection. The following patterns are stripped:
+     *
+     *  - `expression(...)`: IE-only dynamic-expression XSS, still relevant
+     *    for very old browsers and corporate legacy estates.
+     *  - `behavior:` and `-moz-binding`: legacy IE/Firefox script-binding
+     *    properties that load external behavior files.
+     *  - `javascript:` URL scheme inside `url(...)` values: classic XSS vector
+     *    for CSS-driven navigation.
+     *  - `@import`: loading remote stylesheets opens an exfiltration and
+     *    script-injection channel via attacker-controlled `url()` values.
+     *  - `<script>` blocks: defense-in-depth in case the CSS is later
+     *    rendered into an HTML context (e.g. inline `<div style="...">`).
+     *
+     * This is intentionally a denylist - it catches the documented vectors
+     * without breaking legitimate CSS. New attack vectors are mitigated by
+     * the CSP nonce requirement on injected `<style>` elements (see
+     * `public/assets/js/checkout.js`).
+     *
+     * @param string $css Raw brand-supplied CSS.
+     * @return string Sanitized CSS with known XSS vectors removed.
+     */
+    private function sanitizeBrandCss(string $css): string
+    {
+        // Strip legacy dynamic-expression / behavior-binding properties.
+        $css = (string) preg_replace('/expression\s*\(/i', '(', $css);
+        $css = (string) preg_replace('/-?behavior\s*:/i', 'x-behavior-disabled:', $css);
+        $css = (string) preg_replace('/-moz-binding\s*:/i', 'x-moz-binding-disabled:', $css);
+
+        // Neutralize javascript: URLs inside url(...) values.
+        $css = (string) preg_replace('/url\s*\(\s*["\']?\s*javascript\s*:/i', 'url(', $css);
+
+        // Block @import - remote stylesheets are an exfiltration + injection
+        // channel; brand CSS should be self-contained.
+        $css = (string) preg_replace('/@import\b[^;]*;?/i', '', $css);
+
+        // Defense-in-depth: strip any embedded <script> blocks in case the
+        // CSS is ever rendered into an HTML context.
+        $css = (string) preg_replace('/<\s*script\b[^>]*>(.*?)<\s*\/\s*script\s*>/is', '', $css);
+
+        return $css;
     }
 }

--- a/src/Controller/Admin/SmsTemplateAdminController.php
+++ b/src/Controller/Admin/SmsTemplateAdminController.php
@@ -6,6 +6,7 @@ namespace OwnPay\Controller\Admin;
 use OwnPay\Container;
 use OwnPay\Service\Admin\AdminSession;
 use OwnPay\Service\Sms\SmartSmsAnalyzer;
+use OwnPay\Service\Sms\SmsRegexParser;
 use OwnPay\Http\Request;
 use OwnPay\Http\Response;
 use OwnPay\Repository\SmsTemplateRepository;
@@ -187,15 +188,21 @@ final class SmsTemplateAdminController
         $statusVal = $data['status'] ?? 'active';
         $status = is_string($statusVal) ? $statusVal : 'active';
 
-        $this->tplRepo->createTemplate($mid, [
-            'gateway_slug'   => $gatewaySlug,
-            'sender_pattern' => $senderPattern,
-            'amount_regex'   => $amountRegex,
-            'trx_id_regex'   => $trxIdRegex,
-            'sender_regex'   => $senderRegex,
-            'priority'       => $priority,
-            'status'         => $status,
-        ]);
+        try {
+            $this->tplRepo->createTemplate($mid, [
+                'gateway_slug'   => $gatewaySlug,
+                'sender_pattern' => $senderPattern,
+                'amount_regex'   => $amountRegex,
+                'trx_id_regex'   => $trxIdRegex,
+                'sender_regex'   => $senderRegex,
+                'priority'       => $priority,
+                'status'         => $status,
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            // Regex syntax validation rejected the payload (issue #66).
+            $this->session->flashError($e->getMessage());
+            return Response::redirect('/admin/sms-center');
+        }
 
         $this->session->flashSuccess('Parsing template created.');
         return Response::redirect('/admin/sms-center');
@@ -247,15 +254,21 @@ final class SmsTemplateAdminController
             $statusVal = $data['status'] ?? 'active';
             $status = is_string($statusVal) ? $statusVal : 'active';
 
-            $this->tplRepo->updateTemplate($id, $mid, [
-                'gateway_slug'   => $gatewaySlug,
-                'sender_pattern' => $senderPattern,
-                'amount_regex'   => $amountRegex,
-                'trx_id_regex'   => $trxIdRegex,
-                'sender_regex'   => $senderRegex,
-                'priority'       => $priority,
-                'status'         => $status,
-            ]);
+            try {
+                $this->tplRepo->updateTemplate($id, $mid, [
+                    'gateway_slug'   => $gatewaySlug,
+                    'sender_pattern' => $senderPattern,
+                    'amount_regex'   => $amountRegex,
+                    'trx_id_regex'   => $trxIdRegex,
+                    'sender_regex'   => $senderRegex,
+                    'priority'       => $priority,
+                    'status'         => $status,
+                ]);
+            } catch (\InvalidArgumentException $e) {
+                // Regex syntax validation rejected the payload (issue #66).
+                $this->session->flashError($e->getMessage());
+                return Response::redirect('/admin/sms-center');
+            }
 
             $this->session->flashSuccess('Template updated.');
             return Response::redirect('/admin/sms-center');
@@ -306,36 +319,52 @@ final class SmsTemplateAdminController
     /**
      * Live regex test endpoint (AJAX).
      *
+     * Accepts both JSON and form-urlencoded payloads (issue #65) so the admin
+     * JS callers (`sms-center.js`, `sms-template-edit.js`) work regardless of
+     * the Content-Type they send. The match itself is delegated to
+     * {@see SmsRegexParser::testPattern()} so the preview reflects exactly
+     * what the production parser will do, including the bounded backtracking
+     * budget and the case-insensitive `/i` modifier applied to undelimited
+     * fragments (issue #67).
+     *
      * @param Request $req The incoming HTTP request.
      * @return Response The JSON response with match results.
      */
     public function testRegex(Request $req): Response
     {
-        $smsBodyRaw  = $req->post('sms_body', '');
+        // Use input() so JSON bodies are read correctly; falls back to POST
+        // form fields for legacy callers (issue #65).
+        $smsBodyRaw  = $req->input('sms_body', '');
         $smsBody = is_string($smsBodyRaw) ? $smsBodyRaw : '';
-        $regexRaw    = $req->post('regex', '');
+        $regexRaw    = $req->input('regex', '');
         $regex = is_string($regexRaw) ? $regexRaw : '';
-        $fieldRaw    = $req->post('field', 'amount'); // amount, trx_id, sender
+        $fieldRaw    = $req->input('field', 'amount'); // amount, trx_id, sender
         $field = is_string($fieldRaw) ? $fieldRaw : 'amount';
 
-        if (empty($regex) || empty($smsBody)) {
+        if ($regex === '' || $smsBody === '') {
             return Response::json(['success' => false, 'error' => 'Both SMS body and regex required.']);
         }
 
-        // Validate regex is safe
-        if (@preg_match('/' . $regex . '/', '') === false) {
+        $parser = new SmsRegexParser();
+        $result = $parser->testPattern($regex, $smsBody);
+
+        // testPattern returns matched=false for syntactically invalid patterns;
+        // surface that explicitly so the admin sees a distinct error message
+        // rather than a silent "no match".
+        $wrappedPattern = '/' . str_replace('/', '\\/', $regex) . '/';
+        if ($result['match'] === null && @preg_match($wrappedPattern, '') === false && @preg_match($regex, '') === false) {
+            // Pattern is invalid when neither the wrapped nor raw form parses.
+            // We rely on the wrapped check first because the raw regex may
+            // already include its own delimiters.
             return Response::json(['success' => false, 'error' => 'Invalid regex pattern.']);
         }
 
-        $matches = [];
-        $found = preg_match('/' . $regex . '/', $smsBody, $matches);
-
         return Response::json([
             'success'  => true,
-            'matched'  => (bool) $found,
+            'matched'  => $result['matched'],
             'field'    => $field,
-            'match'    => $matches[1] ?? ($matches[0] ?? null),
-            'full'     => $matches,
+            'match'    => $result['match'],
+            'full'     => $result['full'],
         ]);
     }
 
@@ -439,15 +468,21 @@ final class SmsTemplateAdminController
         $priorityVal = $data['priority'] ?? 10;
         $priority = is_scalar($priorityVal) && is_numeric($priorityVal) ? (int) $priorityVal : 10;
 
-        $this->tplRepo->createTemplate($mid, [
-            'gateway_slug'   => $gatewaySlug,
-            'sender_pattern' => $senderPattern,
-            'amount_regex'   => $amountRegex,
-            'trx_id_regex'   => $trxIdRegex,
-            'sender_regex'   => $senderRegex,
-            'priority'       => $priority,
-            'status'         => 'active',
-        ]);
+        try {
+            $this->tplRepo->createTemplate($mid, [
+                'gateway_slug'   => $gatewaySlug,
+                'sender_pattern' => $senderPattern,
+                'amount_regex'   => $amountRegex,
+                'trx_id_regex'   => $trxIdRegex,
+                'sender_regex'   => $senderRegex,
+                'priority'       => $priority,
+                'status'         => 'active',
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            // Regex syntax validation rejected the payload (issue #66).
+            $this->session->flashError($e->getMessage());
+            return Response::redirect('/admin/sms-center');
+        }
 
         $this->session->flashSuccess("Template for '{$gatewaySlug}' saved from analysis");
         return Response::redirect('/admin/sms-center');

--- a/src/Controller/Api/TransactionController.php
+++ b/src/Controller/Api/TransactionController.php
@@ -131,6 +131,11 @@ final class TransactionController
     /**
      * Map transaction data to a safe output schema matching database definitions.
      *
+     * Includes the `payment_intent_id` so API clients can correlate a trx_id
+     * back to the original payment intent UUID (issue #59). Without this field,
+     * merchants who only retained the UUID returned by POST /api/v1/payments
+     * had no API path from trx_id back to that UUID.
+     *
      * @param array<string, mixed> $t The database transaction record array.
      * @return array<string, mixed> The filtered, safe presentation array representation.
      */
@@ -139,6 +144,7 @@ final class TransactionController
         return [
             'id'          => $t['id'],
             'trx_id'      => $t['trx_id'],
+            'payment_intent_id' => $t['payment_intent_id'] ?? null,
             'gateway_trx_id' => $t['gateway_trx_id'] ?? null,
             'amount'      => $t['amount'],
             'currency'    => $t['currency'],

--- a/src/Controller/Checkout/CheckoutController.php
+++ b/src/Controller/Checkout/CheckoutController.php
@@ -363,6 +363,33 @@ final class CheckoutController
             }
         }
 
+        // Issue #71: auto-redirect to merchant after successful payment.
+        // When the brand setting is enabled, expose the merchant return URL
+        // so the checkout-status template can run the same countdown + redirect
+        // flow the PaymentIntent path already uses. The return URL is sourced
+        // from the transaction metadata (return_url/merchant_url/redirect_url)
+        // so per-payment merchant overrides win over a brand-wide default.
+        $merchantRedirectUrl = '';
+        $autoRedirect = false;
+        if (is_array($txn) && ($status === 'success' || $status === 'completed')) {
+            $autoRedirectVal = $this->settings->get('checkout', 'auto_redirect_to_merchant', '0');
+            $autoRedirect = is_string($autoRedirectVal) && $autoRedirectVal === '1';
+            if ($autoRedirect) {
+                $metaRaw = $txn['metadata'] ?? '{}';
+                $metaStr = is_string($metaRaw) ? $metaRaw : '{}';
+                $meta = json_decode($metaStr, true);
+                $meta = is_array($meta) ? $meta : [];
+                $candidateKeys = ['return_url', 'merchant_url', 'redirect_url', 'success_url'];
+                foreach ($candidateKeys as $key) {
+                    $val = $meta[$key] ?? null;
+                    if (is_string($val) && $val !== '') {
+                        $merchantRedirectUrl = $val;
+                        break;
+                    }
+                }
+            }
+        }
+
         $tplFilter = $this->events->applyFilter('checkout.status.template', 'checkout/checkout-status.twig');
         $tplName = is_string($tplFilter) ? $tplFilter : 'checkout/checkout-status.twig';
         $brandId = $mid > 0 ? $mid : null;
@@ -376,6 +403,11 @@ final class CheckoutController
                 'pending_msg' => (!empty($brand['checkout_pending_msg']) && is_string($brand['checkout_pending_msg'])) ? $brand['checkout_pending_msg'] : (is_string($this->settings->get('checkout', 'checkout_pending_msg', '')) ? $this->settings->get('checkout', 'checkout_pending_msg', '') : (is_string($this->settings->get('general', 'checkout_pending_msg', '')) ? $this->settings->get('general', 'checkout_pending_msg', '') : '')),
                 'failed_msg'  => (!empty($brand['checkout_failed_msg']) && is_string($brand['checkout_failed_msg'])) ? $brand['checkout_failed_msg'] : (is_string($this->settings->get('checkout', 'checkout_failed_msg', '')) ? $this->settings->get('checkout', 'checkout_failed_msg', '') : (is_string($this->settings->get('general', 'checkout_failed_msg', '')) ? $this->settings->get('general', 'checkout_failed_msg', '') : '')),
             ],
+            // Pass through the auto-redirect signals so the shared status
+            // template's countdown block runs for classic-checkout success
+            // when the merchant has enabled the toggle.
+            'auto_redirect'        => $autoRedirect,
+            'merchant_redirect_url' => $merchantRedirectUrl,
         ]);
     }
 
@@ -579,16 +611,27 @@ final class CheckoutController
             // otherwise an arbitrary client-supplied string gets stored as gateway_slug.
             $platformId = ($brandCtx instanceof \OwnPay\Service\Brand\BrandContext) ? $brandCtx->getPlatformId() : 0;
             $activeManualGateways = $this->manualGw->listActiveForCheckout($mid, $platformId);
-            $isActiveManual = false;
+            $selectedGw = null;
             foreach ($activeManualGateways as $gw) {
                 if (($gw['slug'] ?? '') === $gateway) {
-                    $isActiveManual = true;
+                    $selectedGw = $gw;
                     break;
                 }
             }
-            if (!$isActiveManual) {
+            if ($selectedGw === null) {
                 if ($req->isAjax()) {
                     return Response::json(['success' => false, 'error' => 'Selected gateway is not active.'], 422);
+                }
+                return $this->renderStatus($token, 'expired');
+            }
+
+            // Enforce configured min_amount / max_amount limits (issue #57).
+            // Limits are stored as bcmath strings; comparison must use bccomp,
+            // never float math, to preserve financial correctness.
+            $limitError = $this->validateManualGatewayAmount($selectedGw, $txnAmount);
+            if ($limitError !== null) {
+                if ($req->isAjax()) {
+                    return Response::json(['success' => false, 'error' => $limitError], 422);
                 }
                 return $this->renderStatus($token, 'expired');
             }
@@ -890,8 +933,11 @@ final class CheckoutController
             return $this->renderStatus($token, 'expired');
         }
 
+        $senderNumberRaw = $req->input('sender_number', '');
+        $senderNumber = is_string($senderNumberRaw) ? trim($senderNumberRaw) : '';
+
         $verifyData = [
-            'sender_number'  => $req->input('sender_number', ''),
+            'sender_number'  => $senderNumber,
             'transaction_id' => $req->input('transaction_id', ''),
             'submitted_at'   => DateHelper::now(),
         ];
@@ -910,6 +956,18 @@ final class CheckoutController
         $merchantId = (is_int($merchantIdVal) || is_string($merchantIdVal)) ? (int) $merchantIdVal : 0;
 
         $this->txnRepo->setStatusWithMeta($txnId, 'pending_review', $existingMeta, $merchantId);
+
+        // Persist the customer-supplied sender number into the dedicated
+        // op_transactions.sender_account column (issue #56). The metadata write
+        // above keeps the historical audit trail; this column write makes the
+        // value visible to the admin transaction detail UI, the notification
+        // bell, and downstream consumers that read sender_account directly
+        // instead of digging through metadata.verification.sender_number.
+        if ($senderNumber !== '') {
+            $this->txnRepo->forTenant($merchantId)->updateScoped($txnId, [
+                'sender_account' => $senderNumber,
+            ]);
+        }
 
         $this->events->doAction('checkout.manual_verify.submitted', $txn, $verifyData);
 
@@ -1092,5 +1150,48 @@ final class CheckoutController
             'success' => false,
             'error'   => 'Payment service is not configured.',
         ], 500);
+    }
+
+    /**
+     * Validates a transaction amount against a manual gateway's configured limits.
+     *
+     * Manual gateway min_amount/max_amount are persisted in admin but were never
+     * enforced at checkout (issue #57). Returns a human-readable error string
+     * when the amount is outside the configured range, or null when the amount
+     * is acceptable (or when the gateway has no limits configured).
+     *
+     * Comparisons use bccomp with 2-decimal precision to preserve financial
+     * correctness; float math is forbidden for money per the project conventions.
+     *
+     * @param array<string, mixed> $gateway The manual gateway row, including min_amount/max_amount.
+     * @param string $amount The transaction amount as a numeric string.
+     * @return string|null Error message when out of range, null when acceptable.
+     */
+    private function validateManualGatewayAmount(array $gateway, string $amount): ?string
+    {
+        if (!is_numeric($amount)) {
+            return 'Invalid amount.';
+        }
+
+        $minRaw = $gateway['min_amount'] ?? '0';
+        $minAmount = (is_string($minRaw) || is_int($minRaw) || is_float($minRaw)) ? (string) $minRaw : '0';
+        if (!is_numeric($minAmount)) {
+            $minAmount = '0';
+        }
+
+        $maxRaw = $gateway['max_amount'] ?? '0';
+        $maxAmount = (is_string($maxRaw) || is_int($maxRaw) || is_float($maxRaw)) ? (string) $maxRaw : '0';
+        if (!is_numeric($maxAmount)) {
+            $maxAmount = '0';
+        }
+
+        if (bccomp($minAmount, '0', 2) > 0 && bccomp($amount, $minAmount, 2) < 0) {
+            return "Amount must be at least {$minAmount}.";
+        }
+        if (bccomp($maxAmount, '0', 2) > 0 && bccomp($amount, $maxAmount, 2) > 0) {
+            return "Amount must not exceed {$maxAmount}.";
+        }
+
+        return null;
     }
 }

--- a/src/Controller/Checkout/PaymentIntentCheckoutController.php
+++ b/src/Controller/Checkout/PaymentIntentCheckoutController.php
@@ -369,6 +369,9 @@ final class PaymentIntentCheckoutController
             $gwColorsStr = is_string($gwColorsRaw) ? $gwColorsRaw : '{}';
             $gwColors = json_decode($gwColorsStr, true);
 
+            $logoPathVal = $gw['logo_path'] ?? null;
+            $qrCodePathVal = $gw['qr_code_path'] ?? null;
+
             $manualDetails[$slug] = [
                 'name'               => is_string($gw['name'] ?? null) ? $gw['name'] : '',
                 'input_fields'       => $inputFields,
@@ -377,6 +380,13 @@ final class PaymentIntentCheckoutController
                 'payment_number'     => $paymentNumber,
                 'converted_amount'   => $convAmount,
                 'converted_currency' => $convCurrency,
+                // Issue #58: classic checkout already includes these keys; the
+                // PaymentIntent flow omitted them, so the shared checkout.js
+                // renderer never found logo_path/qr_code_path and silently
+                // dropped both the logo and the QR code on API-initiated
+                // checkouts. Mirroring the classic payload shape fixes both.
+                'logo_path'          => is_string($logoPathVal) ? $logoPathVal : null,
+                'qr_code_path'       => is_string($qrCodePathVal) ? $qrCodePathVal : null,
             ];
         }
 
@@ -679,6 +689,38 @@ final class PaymentIntentCheckoutController
         $txnId = (is_int($txnIdVal) || is_string($txnIdVal)) ? (int) $txnIdVal : 0;
 
         if ($gatewayMode === 'manual') {
+            // Assert the submitted gateway is one of this merchant's actually-configured
+            // active manual gateways and enforce configured min_amount/max_amount limits
+            // (issue #57). Without this guard, an arbitrary client-supplied string would
+            // be stored as gateway_slug and configured amount limits would be silently
+            // ignored - matching the gap that existed in CheckoutController::pay().
+            $platformId = ($brandCtx instanceof \OwnPay\Service\Brand\BrandContext) ? $brandCtx->getPlatformId() : 0;
+            $activeManualGateways = $this->manualGw->listActiveForCheckout($mid, $platformId);
+            $selectedGw = null;
+            foreach ($activeManualGateways as $gw) {
+                if (($gw['slug'] ?? '') === $gateway) {
+                    $selectedGw = $gw;
+                    break;
+                }
+            }
+            if ($selectedGw === null) {
+                if ($req->isAjax()) {
+                    return Response::json(['success' => false, 'error' => 'Selected gateway is not active.'], 422);
+                }
+                return $this->renderStatus($token, 'expired', $intent);
+            }
+
+            // Enforce configured min_amount / max_amount using the post-conversion
+            // amount the gateway will actually see (matches the currency the limits
+            // were configured in - admin sets limits in the gateway's home currency).
+            $limitError = $this->validateManualGatewayAmount($selectedGw, $amount);
+            if ($limitError !== null) {
+                if ($req->isAjax()) {
+                    return Response::json(['success' => false, 'error' => $limitError], 422);
+                }
+                return $this->renderStatus($token, 'expired', $intent);
+            }
+
             $this->txnRepo->setGatewayAndStatus($txnId, $gateway, 'awaiting_verification', $mid);
             $details = $req->post('payment_details', []);
             if (!empty($details) && is_array($details)) {
@@ -1052,8 +1094,11 @@ final class PaymentIntentCheckoutController
         $txnIdVal = $txn['id'] ?? 0;
         $txnId = (is_int($txnIdVal) || is_string($txnIdVal)) ? (int) $txnIdVal : 0;
 
+        $senderNumberRaw = $req->input('sender_number', '');
+        $senderNumber = is_string($senderNumberRaw) ? trim($senderNumberRaw) : '';
+
         $verifyData = [
-            'sender_number'  => $req->input('sender_number', ''),
+            'sender_number'  => $senderNumber,
             'transaction_id' => $req->input('transaction_id', ''),
             'submitted_at'   => DateHelper::now(),
         ];
@@ -1065,6 +1110,17 @@ final class PaymentIntentCheckoutController
         $existingMeta['verification'] = $verifyData;
 
         $this->txnRepo->setStatusWithMeta($txnId, 'pending_review', $existingMeta, $mid);
+
+        // Persist the customer-supplied sender number into the dedicated
+        // op_transactions.sender_account column (issue #56). Mirrors the
+        // classic CheckoutController::manualVerify() behaviour so both flows
+        // expose the value to admin UI, notification bell, and downstream
+        // consumers that read sender_account directly.
+        if ($senderNumber !== '') {
+            $this->txnRepo->forTenant($mid)->updateScoped($txnId, [
+                'sender_account' => $senderNumber,
+            ]);
+        }
 
         // Elevate checkout intent status to reflect review processing.
         $this->intents->forTenant($mid)->updateScoped($intentId, ['status' => 'processing']);
@@ -1417,5 +1473,45 @@ final class PaymentIntentCheckoutController
         }
 
         return Response::json(['success' => false, 'error' => 'Payment service is not configured.'], 500);
+    }
+
+    /**
+     * Validates a transaction amount against a manual gateway's configured limits.
+     *
+     * Mirrors {@see \OwnPay\Controller\Checkout\CheckoutController::validateManualGatewayAmount()}
+     * so both checkout flows enforce the same min_amount/max_amount rules (issue #57).
+     * Comparisons use bccomp with 2-decimal precision; float math is forbidden
+     * for money per the project conventions.
+     *
+     * @param array<string, mixed> $gateway The manual gateway row, including min_amount/max_amount.
+     * @param string $amount The transaction amount as a numeric string.
+     * @return string|null Error message when out of range, null when acceptable.
+     */
+    private function validateManualGatewayAmount(array $gateway, string $amount): ?string
+    {
+        if (!is_numeric($amount)) {
+            return 'Invalid amount.';
+        }
+
+        $minRaw = $gateway['min_amount'] ?? '0';
+        $minAmount = (is_string($minRaw) || is_int($minRaw) || is_float($minRaw)) ? (string) $minRaw : '0';
+        if (!is_numeric($minAmount)) {
+            $minAmount = '0';
+        }
+
+        $maxRaw = $gateway['max_amount'] ?? '0';
+        $maxAmount = (is_string($maxRaw) || is_int($maxRaw) || is_float($maxRaw)) ? (string) $maxRaw : '0';
+        if (!is_numeric($maxAmount)) {
+            $maxAmount = '0';
+        }
+
+        if (bccomp($minAmount, '0', 2) > 0 && bccomp($amount, $minAmount, 2) < 0) {
+            return "Amount must be at least {$minAmount}.";
+        }
+        if (bccomp($maxAmount, '0', 2) > 0 && bccomp($amount, $maxAmount, 2) > 0) {
+            return "Amount must not exceed {$maxAmount}.";
+        }
+
+        return null;
     }
 }

--- a/src/Middleware/DomainMiddleware.php
+++ b/src/Middleware/DomainMiddleware.php
@@ -72,6 +72,23 @@ final class DomainMiddleware
             $domain = $colonPos !== false ? substr($host, 0, $colonPos) : $host;
         }
 
+        // Normalize the domain for case-insensitive, IDN-safe matching
+        // (issues #74/#80). DNS is case-insensitive by spec, so we lowercase
+        // before lookup; otherwise a customer typing `Brand.com` would get a
+        // 404 even though `brand.com` is configured. When the intl extension
+        // is available we also convert IDN unicode (e.g. `bränd.com`) to its
+        // ASCII punycode form (`xn--brnd-5na.com`) so the same configured
+        // record matches both representations. intl is optional - when it is
+        // missing, only the case-normalization runs, which still closes the
+        // most common mismatch.
+        $domain = mb_strtolower($domain, 'UTF-8');
+        if (function_exists('idn_to_ascii')) {
+            $converted = @idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+            if (is_string($converted) && $converted !== '') {
+                $domain = $converted;
+            }
+        }
+
         // Compare normalized hostname against the resolved system-wide master domain and localhost.
         // Standard admin panel routes are directly processed without mapping tenant scopes.
         $masterDomain = $this->resolveMasterDomain();
@@ -208,7 +225,7 @@ final class DomainMiddleware
         $appDomainVal = $_ENV['APP_DOMAIN'] ?? $_SERVER['APP_DOMAIN'] ?? getenv('APP_DOMAIN') ?: '';
         $appDomain = is_string($appDomainVal) ? $appDomainVal : '';
         if ($appDomain !== '') {
-            return $appDomain;
+            return mb_strtolower($appDomain, 'UTF-8');
         }
 
         // Step 2: Extract host section from the APP_URL environment variable.
@@ -217,7 +234,7 @@ final class DomainMiddleware
         if ($appUrl !== '') {
             $parsed = parse_url($appUrl, PHP_URL_HOST);
             if (is_string($parsed)) {
-                return $parsed;
+                return mb_strtolower($parsed, 'UTF-8');
             }
         }
 

--- a/src/Repository/DomainRepository.php
+++ b/src/Repository/DomainRepository.php
@@ -23,12 +23,27 @@ final class DomainRepository extends BaseRepository
     /**
      * Finds a domain record by hostname.
      *
-     * @param string $domain The target domain hostname.
+     * Matching is **case-insensitive** (issues #74/#80): DNS is case-insensitive
+     * by specification, so `Brand.com`, `brand.com`, and `BRAND.COM` all refer to
+     * the same origin. A case-sensitive (BINARY) match here would silently fail to
+     * resolve a configured domain when the client sent a different casing,
+     * routing the customer to a 404 instead of their checkout page. Mirrors the
+     * pattern already used by SmsTemplateRepository::findBySender().
+     *
+     * IDN (internationalized domain name) handling: when the PHP `intl` extension
+     * is available, callers should pass the ASCII (punycode) form of the host.
+     * The middleware performs that conversion before lookup so the same record
+     * matches both the unicode and punycode representations.
+     *
+     * @param string $domain The target domain hostname (already lowercased + ASCII-normalized by the caller).
      * @return array<string, mixed>|null Domain database record, or null if not found.
      */
     public function findByDomain(string $domain): ?array
     {
-        return $this->findBy('domain', $domain);
+        return $this->db->fetchOne(
+            "SELECT * FROM {$this->table} WHERE LOWER(domain) = LOWER(:domain) LIMIT 1",
+            ['domain' => $domain]
+        );
     }
 
     /**

--- a/src/Repository/SmsDataRepository.php
+++ b/src/Repository/SmsDataRepository.php
@@ -43,14 +43,50 @@ final class SmsDataRepository extends BaseRepository
      * from the same device, matching sender, and matching received timestamp
      * within a strict ±1 second tolerance window.
      *
+     * When a content fingerprint is supplied (issue #63), two messages with the
+     * same device/sender/timestamp but distinct content are treated as distinct
+     * events. Without the fingerprint the legacy behaviour is preserved so
+     * existing callers and tests continue to work. The fingerprint is derived
+     * from the encrypted payload before decryption, so it is available at the
+     * point of the dedup check.
+     *
      * @param string $deviceId The pairing identifier of the originating device.
      * @param string $sender The raw sender address or number.
      * @param string $receivedAt The date-time string of when the SMS was received.
+     * @param string|null $contentFingerprint Optional normalized hash of the SMS body or encrypted payload.
      * @return bool True if a matching duplicate is found, false otherwise.
      * @throws \LogicException If the active tenant context cannot be resolved.
      */
-    public function isDuplicate(string $deviceId, string $sender, string $receivedAt): bool
+    public function isDuplicate(string $deviceId, string $sender, string $receivedAt, ?string $contentFingerprint = null): bool
     {
+        // When a content fingerprint is provided, a duplicate requires the same
+        // fingerprint too. We perform a single EXISTS query that is satisfied
+        // only when an identical (device, sender, timestamp, content) row exists.
+        if ($contentFingerprint !== null && $contentFingerprint !== '') {
+            $row = $this->db->fetchOne(
+                "SELECT 1 AS hit FROM {$this->table}
+                 WHERE device_id = :did AND sender = :sender
+                   AND ABS(TIMESTAMPDIFF(SECOND, received_at, :received_at)) <= 1
+                   AND merchant_id = :mid
+                   AND (
+                       MD5(encrypted_raw) = :fp
+                       OR MD5(body) = :fp2
+                       OR local_id = :lid
+                   )
+                 LIMIT 1",
+                [
+                    'did'         => $deviceId,
+                    'sender'      => $sender,
+                    'received_at' => $receivedAt,
+                    'mid'         => $this->requireTenant(),
+                    'fp'          => $contentFingerprint,
+                    'fp2'         => $contentFingerprint,
+                    'lid'         => $contentFingerprint,
+                ]
+            );
+            return $row !== null;
+        }
+
         $row = $this->db->fetchOne(
             "SELECT COUNT(*) as cnt FROM {$this->table}
              WHERE device_id = :did AND sender = :sender

--- a/src/Repository/SmsTemplateRepository.php
+++ b/src/Repository/SmsTemplateRepository.php
@@ -136,12 +136,20 @@ final class SmsTemplateRepository extends BaseRepository
     /**
      * Creates a new parsing template for the specified merchant.
      *
+     * Regex fields are syntax-validated before persistence (issue #66). An
+     * invalid pattern is rejected with a {@see \InvalidArgumentException} so
+     * the controller can surface a clear error to the admin instead of
+     * silently saving a template that will never match anything in production.
+     *
      * @param int $merchantId The unique identifier of the merchant brand.
      * @param array<string, mixed> $data Field value pairs containing configuration patterns.
      * @return string The newly generated template's auto-increment or primary key.
+     * @throws \InvalidArgumentException When any supplied regex field is syntactically invalid.
      */
     public function createTemplate(int $merchantId, array $data): string
     {
+        $this->assertRegexFields($data);
+
         return $this->create([
             'merchant_id'    => $merchantId,
             'gateway_slug'   => $data['gateway_slug'] ?? '',
@@ -157,13 +165,19 @@ final class SmsTemplateRepository extends BaseRepository
     /**
      * Updates parsing template fields for a given merchant.
      *
+     * Regex fields are syntax-validated before persistence (issue #66). An
+     * invalid pattern is rejected with a {@see \InvalidArgumentException}.
+     *
      * @param int $id The internal primary key of the target template.
      * @param int $merchantId The unique identifier of the merchant brand.
      * @param array<string, mixed> $data Set of field key-value pairs to modify.
      * @return void
+     * @throws \InvalidArgumentException When any supplied regex field is syntactically invalid.
      */
     public function updateTemplate(int $id, int $merchantId, array $data): void
     {
+        $this->assertRegexFields($data);
+
         $fields = [];
         $params = ['id' => $id, 'mid' => $merchantId];
         $allowed = ['gateway_slug', 'sender_pattern', 'amount_regex', 'trx_id_regex', 'sender_regex', 'priority', 'status'];
@@ -181,6 +195,56 @@ final class SmsTemplateRepository extends BaseRepository
 
         $sql = "UPDATE {$this->table} SET " . implode(', ', $fields) . " WHERE id = :id AND merchant_id = :mid";
         $this->db->execute($sql, $params);
+    }
+
+    /**
+     * Validates the syntax of every regex field present in the payload.
+     *
+     * A pattern is considered valid when it parses (preg_match against the
+     * empty string returns 0 or 1, not false) after delimiter normalization.
+     * Empty patterns are allowed - they simply mean "do not capture this field".
+     *
+     * @param array<string, mixed> $data Field value pairs to inspect.
+     * @throws \InvalidArgumentException When any regex field is syntactically invalid.
+     */
+    private function assertRegexFields(array $data): void
+    {
+        $regexFields = ['amount_regex', 'trx_id_regex', 'sender_regex'];
+        foreach ($regexFields as $field) {
+            $value = $data[$field] ?? '';
+            if (!is_string($value) || $value === '') {
+                continue;
+            }
+            $pattern = $this->normalizePatternForValidation($value);
+            if (@preg_match($pattern, '') === false) {
+                throw new \InvalidArgumentException(
+                    "Invalid regex syntax for field '{$field}': {$value}"
+                );
+            }
+        }
+    }
+
+    /**
+     * Wraps a raw regex fragment with delimiters for syntax validation only.
+     *
+     * Production matching uses {@see \OwnPay\Service\Sms\SmsRegexParser::ensureDelimiters()},
+     * but the repository cannot depend on that service without creating a
+     * circular dependency. This local mirror performs the same normalization
+     * for the sole purpose of validating syntax before persistence.
+     *
+     * @param string $regex Raw regex fragment.
+     * @return string Delimiter-wrapped pattern suitable for preg_match validation.
+     */
+    private function normalizePatternForValidation(string $regex): string
+    {
+        $regex = trim($regex);
+        if ($regex === '') {
+            return '//';
+        }
+        if (preg_match('/^([^\w\s\\\\\\\\]).*\1[a-z]*$/is', $regex)) {
+            return $regex;
+        }
+        return '/' . str_replace('/', '\\/', $regex) . '/i';
     }
 
     /**

--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -27,8 +27,8 @@ final class TransactionRepository extends BaseRepository
     protected array $fillable = [
         'merchant_id', 'uuid', 'trx_id', 'payment_intent_id', 'customer_id',
         'gateway_slug', 'amount', 'fee', 'net_amount', 'currency',
-        'sender_account', 'reference', 'gateway_trx_id', 'ip_address', 'method',
-        'status', 'metadata', 'completed_at',
+        'sender_account', 'reference', 'gateway_trx_id', 'provider_trx_id',
+        'ip_address', 'method', 'status', 'metadata', 'completed_at',
     ];
 
     /**
@@ -902,11 +902,33 @@ final class TransactionRepository extends BaseRepository
             );
         }
 
+        // Ambiguity guard for the null-timestamp branch (issue #64).
+        // Previously this branch returned ORDER BY created_at DESC LIMIT 1, which
+        // silently auto-completed the most recent pending transaction when
+        // multiple candidates shared the same amount and gateway. That is money-
+        // unsafe: the wrong customer's payment could be marked complete. We now
+        // refuse to auto-match when more than one candidate exists, mirroring the
+        // timestamped branch's "exactly one candidate" rule. A single candidate
+        // still matches so the legitimate unambiguous case continues to work.
+        $sqlCount = "SELECT COUNT(*) FROM {$this->table}
+                     WHERE merchant_id = :mid AND status = 'pending'
+                       AND amount = :amt AND gateway_slug = :gw";
+        $countVal = $this->db->fetchColumn($sqlCount, [
+            'mid' => $merchantId,
+            'amt' => $amount,
+            'gw'  => $gatewaySlug,
+        ]);
+        $count = is_scalar($countVal) ? (int) $countVal : 0;
+
+        if ($count !== 1) {
+            return null;
+        }
+
         return $this->db->fetchOne(
             "SELECT * FROM {$this->table}
              WHERE merchant_id = :mid AND status = 'pending'
                AND amount = :amt AND gateway_slug = :gw
-             ORDER BY created_at DESC LIMIT 1",
+             LIMIT 1",
             ['mid' => $merchantId, 'amt' => $amount, 'gw' => $gatewaySlug]
         );
     }
@@ -955,11 +977,27 @@ final class TransactionRepository extends BaseRepository
             );
         }
 
+        // Ambiguity guard for the null-timestamp branch (issue #64).
+        // Mirrors the scoped findPendingMatch fix: refuse to auto-match when
+        // more than one candidate exists. See findPendingMatch for rationale.
+        $sqlCount = "SELECT COUNT(*) FROM {$this->table}
+                     WHERE status = 'pending'
+                       AND amount = :amt AND gateway_slug = :gw";
+        $countVal = $this->db->fetchColumn($sqlCount, [
+            'amt' => $amount,
+            'gw'  => $gatewaySlug,
+        ]);
+        $count = is_scalar($countVal) ? (int) $countVal : 0;
+
+        if ($count !== 1) {
+            return null;
+        }
+
         return $this->db->fetchOne(
             "SELECT * FROM {$this->table}
              WHERE status = 'pending'
                AND amount = :amt AND gateway_slug = :gw
-             ORDER BY created_at DESC LIMIT 1",
+             LIMIT 1",
             ['amt' => $amount, 'gw' => $gatewaySlug]
         );
     }

--- a/src/Service/Notification/WebhookDispatcher.php
+++ b/src/Service/Notification/WebhookDispatcher.php
@@ -140,7 +140,7 @@ final class WebhookDispatcher
         $intent = null;
         if ($intentId !== null && $intentId > 0) {
             $intent = $this->db->fetchOne(
-                "SELECT amount, currency FROM op_payment_intents WHERE id = :id LIMIT 1",
+                "SELECT uuid, amount, currency FROM op_payment_intents WHERE id = :id LIMIT 1",
                 ['id' => $intentId]
             );
         }
@@ -166,8 +166,23 @@ final class WebhookDispatcher
             }
         }
 
+        // Resolve the payment intent UUID (issue #54/#59). Merchants receive the
+        // UUID when they create a payment intent via POST /api/v1/payments, so
+        // including it in the webhook payload lets them correlate the event back
+        // to the original intent without an extra API call. We prefer the
+        // explicitly-passed payment_id (set by callers that already have it),
+        // then fall back to the intent row's uuid column.
+        $paymentId = '';
+        $paymentIdVal = $data['payment_id'] ?? null;
+        if (is_string($paymentIdVal) && $paymentIdVal !== '') {
+            $paymentId = $paymentIdVal;
+        } elseif (is_array($intent) && isset($intent['uuid']) && is_string($intent['uuid'])) {
+            $paymentId = $intent['uuid'];
+        }
+
         return [
             'event'          => $event,
+            'payment_id'     => $paymentId,
             'transaction_id' => $data['transaction_id'] ?? '',
             'gateway_trx_id' => $gatewayTrxId,
             'amount'         => $amount,

--- a/src/Service/Payment/GatewayApiService.php
+++ b/src/Service/Payment/GatewayApiService.php
@@ -241,6 +241,11 @@ final class GatewayApiService
                         $feeVal = $transaction['fee'] ?? '0.00';
                         $cur = $transaction['currency'] ?? 'BDT';
                         if (is_scalar($txnId) && is_scalar($amt) && is_scalar($feeVal) && is_scalar($cur)) {
+                            // Persist the gateway/provider transaction reference so SMS auto-verification
+                            // can use exact trx_id matching (issue #62). The verification payload from
+                            // the gateway adapter carries the canonical provider-side reference.
+                            $this->persistProviderTrxId((int) $txnId, $merchantId, $gwTrxId, $transaction);
+
                             $this->transactions->complete((int) $txnId, $merchantId);
 
                             // Record in ledger
@@ -331,6 +336,38 @@ final class GatewayApiService
             return true;
         }
         return ($transaction['gateway_slug'] ?? null) === $gatewaySlug;
+    }
+
+    /**
+     * Persists the gateway-supplied transaction reference into op_transactions.provider_trx_id
+     * when it is not already populated.
+     *
+     * The column is the canonical source for exact-trx_id matching in SmsVerificationJob.
+     * We avoid overwriting an existing non-empty value to preserve the first authoritative
+     * reference (replays from gateways occasionally send a different format) and skip the
+     * write entirely when the candidate is empty or already matches the stored value, so
+     * the common path incurs no extra query.
+     *
+     * @param int $transactionId The transaction primary key.
+     * @param int $merchantId The merchant/brand scope.
+     * @param mixed $gatewayTrxId The gateway-side transaction reference returned by verification.
+     * @param array<string, mixed> $transaction The locked transaction row, used to skip redundant writes.
+     */
+    private function persistProviderTrxId(int $transactionId, int $merchantId, mixed $gatewayTrxId, array $transaction): void
+    {
+        if (!is_string($gatewayTrxId) || $gatewayTrxId === '') {
+            return;
+        }
+        $existing = $transaction['provider_trx_id'] ?? null;
+        if (is_string($existing) && $existing !== '') {
+            return;
+        }
+        $db = \OwnPay\Core\Database::getInstance();
+        $db->execute(
+            'UPDATE op_transactions SET provider_trx_id = :ptid
+             WHERE id = :id AND merchant_id = :mid AND (provider_trx_id IS NULL OR provider_trx_id = \'\')',
+            ['ptid' => $gatewayTrxId, 'id' => $transactionId, 'mid' => $merchantId]
+        );
     }
 
     /**

--- a/src/Service/Payment/LedgerService.php
+++ b/src/Service/Payment/LedgerService.php
@@ -185,6 +185,23 @@ final class LedgerService
             throw new \RuntimeException("Transaction not found: {$transactionId}");
         }
 
+        // Defense-in-depth brand guard (issue #77): the scoped findScoped()
+        // above already returns null when the transaction does not belong to
+        // $merchantId, so this check is redundant in the normal path. We keep
+        // it as an explicit guard so a future refactor that swaps the lookup
+        // for an unscoped one cannot silently post a refund ledger entry to
+        // the wrong brand's books. The transaction's own currency is also
+        // asserted to match the requested posting currency - a currency
+        // mismatch would indicate a logic error upstream and would unbalance
+        // the brand's books once posted.
+        $txnMerchantVal = $txn['merchant_id'] ?? null;
+        $txnMerchant = is_scalar($txnMerchantVal) ? (int) $txnMerchantVal : 0;
+        if ($txnMerchant !== $merchantId) {
+            throw new \RuntimeException(
+                "Cross-brand refund blocked: transaction #{$transactionId} belongs to merchant {$txnMerchant}, cannot refund from merchant {$merchantId}"
+            );
+        }
+
         $amountVal = $txn['amount'] ?? '0.00';
         $feeVal = $txn['fee'] ?? '0.00';
         $origGross = is_scalar($amountVal) ? (string) $amountVal : '0.00';

--- a/src/Service/Payment/WebhookAutoDispatchListener.php
+++ b/src/Service/Payment/WebhookAutoDispatchListener.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace OwnPay\Service\Payment;
+
+/**
+ * Auto-dispatches merchant webhooks when a payment transaction completes.
+ *
+ * Previously, webhooks were only dispatched from manual admin paths (test
+ * webhook, manual resend) and the retry cron for already-queued events; the
+ * real payment-completion flow fired the `payment.transaction.completed` action
+ * but no listener forwarded the event to merchants (issue #59).
+ *
+ * This listener is wired to `payment.transaction.completed` in
+ * `config/services.php` and forwards the completed transaction payload to
+ * {@see WebhookService::dispatch()} so merchants receive their events without
+ * requiring a manual admin action. The dispatcher is idempotent per webhook
+ * event row, so retries or replays of the completion action do not produce
+ * duplicate deliveries to the same endpoint for the same event id.
+ */
+final class WebhookAutoDispatchListener
+{
+    /**
+     * @var WebhookService Outbound webhook dispatch service.
+     */
+    private WebhookService $webhookService;
+
+    /**
+     * WebhookAutoDispatchListener constructor.
+     *
+     * @param WebhookService $webhookService Outbound webhook dispatch service.
+     */
+    public function __construct(WebhookService $webhookService)
+    {
+        $this->webhookService = $webhookService;
+    }
+
+    /**
+     * Forwards a completed transaction event to all configured merchant webhooks.
+     *
+     * The transaction row carries every field {@see WebhookService::dispatch()}
+     * needs to build the merchant-facing payload (trx_id, gateway_trx_id,
+     * amount, currency, fee, gateway_slug, customer_* fields, metadata,
+     * payment_intent_id). We normalize a handful of keys to the names the
+     * dispatcher expects so the payload is consistent regardless of which
+     * completion path produced the row.
+     *
+     * @param array<string, mixed> $transaction The completed transaction record.
+     * @return void
+     */
+    public function onTransactionCompleted(array $transaction): void
+    {
+        $merchantIdVal = $transaction['merchant_id'] ?? 0;
+        $merchantId = is_scalar($merchantIdVal) ? (int) $merchantIdVal : 0;
+        if ($merchantId <= 0) {
+            return;
+        }
+
+        $customerNameVal  = $transaction['customer_name'] ?? '';
+        $customerEmailVal = $transaction['customer_email'] ?? '';
+        $customerPhoneVal = $transaction['customer_phone'] ?? '';
+
+        $payload = [
+            'transaction_id'     => $transaction['trx_id'] ?? '',
+            'payment_intent_id'  => $transaction['payment_intent_id'] ?? null,
+            'gateway_trx_id'     => $transaction['gateway_trx_id'] ?? '',
+            'amount'             => $transaction['amount'] ?? '0.00',
+            'currency'           => $transaction['currency'] ?? 'BDT',
+            'fee'                => $transaction['fee'] ?? '0.00',
+            'gateway'            => $transaction['gateway_slug'] ?? '',
+            'gateway_type'       => 'unknown',
+            'status'             => $transaction['status'] ?? 'completed',
+            'customer_name'      => is_string($customerNameVal) ? $customerNameVal : '',
+            'customer_email'     => is_string($customerEmailVal) ? $customerEmailVal : '',
+            'customer_phone'     => is_string($customerPhoneVal) ? $customerPhoneVal : '',
+            'metadata'           => $transaction['metadata'] ?? [],
+        ];
+
+        $this->webhookService->dispatch($merchantId, 'payment.completed', $payload);
+    }
+}

--- a/src/Service/Sms/SmartSmsAnalyzer.php
+++ b/src/Service/Sms/SmartSmsAnalyzer.php
@@ -254,7 +254,13 @@ PROMPT;
     /**
      * Validates SMS sender against whitelist rules.
      *
-     * Performs strict, case-sensitive string matching against values.
+     * Matching is **case-insensitive**: carriers send the same alpha sender id
+     * with inconsistent casing ("bKash" / "bkash" / "BKASH"), and the rest of
+     * the pipeline already normalizes for this (see
+     * {@see \OwnPay\Repository\SmsTemplateRepository::findBySender()} which
+     * uses `LOWER(...) = LOWER(...)`). A case-sensitive check here would tell
+     * an admin building a template that a sender is not whitelisted when the
+     * real production pipeline would have matched it fine (issue #68).
      *
      * @param string $sender The sender identity under validation.
      * @return bool True if permitted or if whitelist configurations are empty.
@@ -264,17 +270,40 @@ PROMPT;
         if (empty($this->senderWhitelist)) {
             return true;
         }
-        return in_array($sender, $this->senderWhitelist, strict: true);
+        $senderLower = mb_strtolower($sender, 'UTF-8');
+        foreach ($this->senderWhitelist as $allowed) {
+            if (mb_strtolower((string) $allowed, 'UTF-8') === $senderLower) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * Sanitizes regex patterns for display suggestions.
      *
+     * Strips the outer delimiters and the case-insensitive `/i` modifier (which
+     * the production parser auto-applies to undelimited fragments via
+     * {@see \OwnPay\Service\Sms\SmsRegexParser::ensureDelimiters()}) so the
+     * suggested fragment does not carry redundant flags. The Unicode `/u`
+     * modifier is preserved (issue #69) because ensureDelimiters() does NOT
+     * re-add it, and several built-in patterns rely on it for Bengali text
+     * (the ৳ symbol and Bengali keywords). Dropping it here would silently
+     * downgrade Unicode-aware matching once the suggestion is saved.
+     *
      * @param string $pattern The raw regex string.
-     * @return string Sanitized regex representation without outer delimiters or modifiers.
+     * @return string Sanitized regex representation without outer delimiters, retaining /u when present.
      */
     private function patternToSuggestion(string $pattern): string
     {
-        return (string) preg_replace('/^\/(.*)\/[a-z]*$/u', '$1', $pattern);
+        // Capture the trailing modifier list (everything after the closing delimiter).
+        if (preg_match('/^\/.*\/([a-z]*)$/isu', $pattern, $m)) {
+            $modifiers = $m[1];
+            $keepU = str_contains($modifiers, 'u') ? 'u' : '';
+        } else {
+            $keepU = '';
+        }
+        $body = (string) preg_replace('/^\/(.*)\/[a-z]*$/u', '$1', $pattern);
+        return $keepU !== '' ? $body . $keepU : $body;
     }
 }

--- a/src/Service/Sms/SmsParserService.php
+++ b/src/Service/Sms/SmsParserService.php
@@ -186,7 +186,14 @@ final class SmsParserService
             return $this->makeResult($localId, 'rejected', null, 'MISSING_FIELDS');
         }
 
-        if ($this->dataRepo->isDuplicate($deviceUuid, $sender, $receivedAt)) {
+        // Use the encrypted payload hash as a content fingerprint so two distinct
+        // SMS arriving in the same second from the same sender are not deduped
+        // (issue #63). The encrypted envelope includes a random IV, so two
+        // different plaintexts produce different ciphertexts and therefore
+        // different fingerprints; a replay of the same payload still matches.
+        $contentFingerprint = md5($encrypted);
+
+        if ($this->dataRepo->isDuplicate($deviceUuid, $sender, $receivedAt, $contentFingerprint)) {
             return $this->makeResult($localId, 'duplicate');
         }
 

--- a/src/Service/Sms/SmsRegexParser.php
+++ b/src/Service/Sms/SmsRegexParser.php
@@ -163,7 +163,46 @@ final class SmsRegexParser
     }
 
     /**
+     * Tests a raw regex fragment against a sample SMS body using the same
+     * safety and normalization the production parser applies (issue #67).
+     *
+     * Administrators use this through the regex tester AJAX endpoint. Routing
+     * the test through this method guarantees the preview reflects what the
+     * real parser will do: the pattern is normalized via ensureDelimiters()
+     * (so undelimited fragments pick up the production `/i` modifier) and
+     * the match runs under the bounded backtracking budget so a pathological
+     * pattern cannot hang an admin worker.
+     *
+     * @param string $regex Raw regex fragment as authored by the admin.
+     * @param string $smsBody Sample SMS body to test against.
+     * @return array{matched: bool, match: string|null, full: array<int|string, string>} Test result.
+     */
+    public function testPattern(string $regex, string $smsBody): array
+    {
+        $pattern = $this->ensureDelimiters($regex);
+        if ($pattern === '' || @preg_match($pattern, '') === false) {
+            return ['matched' => false, 'match' => null, 'full' => []];
+        }
+
+        $matches = [];
+        $matched = $this->safeMatch($pattern, $smsBody, $matches);
+
+        $match = $matches[1] ?? $matches[0] ?? null;
+
+        return [
+            'matched' => $matched,
+            'match'   => is_string($match) ? $match : null,
+            'full'    => $matches,
+        ];
+    }
+
+    /**
      * Enforces valid pattern delimiters on raw regular expression inputs.
+     *
+     * When the admin supplies an already-delimited pattern (e.g. `/foo/u`), it
+     * is returned as-is so the original modifiers - including `/u` for Bengali
+     * text - are preserved. Undelimited fragments are wrapped with `/.../i` to
+     * mirror the historical case-insensitive behaviour the parser relied on.
      *
      * @param string $regex The regex under validation.
      * @return string The normalized regular expression with standard delimiters.

--- a/templates/admin/customers/show.twig
+++ b/templates/admin/customers/show.twig
@@ -34,7 +34,7 @@
                 <tbody>
                     {% for txn in transactions %}
                     <tr>
-                        <td data-label="Txn ID"><code>{{ txn.id }}</code></td>
+                        <td data-label="Txn ID"><code>{{ txn.trx_id }}</code></td>
                         <td data-label="Amount">{{ txn.currency }} {{ txn.amount }}</td>
                         <td data-label="Status"><span class="op-badge op-badge-{{ txn.status }}">{{ txn.status|capitalize }}</span></td>
                         <td data-label="Date">{{ txn.created_at|date("M d, Y H:i") }}</td>

--- a/templates/admin/disputes/index.twig
+++ b/templates/admin/disputes/index.twig
@@ -9,8 +9,35 @@
     </div>
     <div class="op-header-actions">
         <span class="op-text-muted op-text-sm">{{ total|default(0) }} total disputes</span>
+        <button type="button" class="op-btn op-btn-primary" onclick="document.getElementById('op-new-dispute-form').classList.toggle('op-d-none')">
+            Open Dispute
+        </button>
     </div>
 </div>
+
+{# Inline create-dispute form (issue #61): surfaces the previously-unreachable
+   DisputeService::open() code path so admins can open disputes without DB access. #}
+<form id="op-new-dispute-form" method="POST" action="/admin/disputes/create" class="op-card op-mb-4 op-d-none">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+    <div class="op-card-header"><h3>Open New Dispute</h3></div>
+    <div class="op-card-body op-grid op-grid-3">
+        <div class="op-form-group">
+            <label>Transaction ID</label>
+            <input type="number" name="transaction_id" class="op-input" required min="1" placeholder="e.g. 1024">
+        </div>
+        <div class="op-form-group">
+            <label>Reason</label>
+            <input type="text" name="reason" class="op-input" required maxlength="100" placeholder="e.g. chargeback">
+        </div>
+        <div class="op-form-group">
+            <label>Amount</label>
+            <input type="text" name="amount" class="op-input" required pattern="\d+(\.\d{1,2})?" placeholder="e.g. 99.50">
+        </div>
+    </div>
+    <div class="op-card-footer op-text-right">
+        <button type="submit" class="op-btn op-btn-success">Open Dispute</button>
+    </div>
+</form>
 
 {# -- Disputes Table ------------------------------------------ #}
 <div class="op-card">

--- a/templates/admin/settings/index.twig
+++ b/templates/admin/settings/index.twig
@@ -795,6 +795,20 @@
                         <small class="op-text-muted">Default: 600 (10 minutes). Range: 60–3600 seconds.</small>
                     </div>
                 </div>
+
+                {# Issue #71: Auto-redirect to merchant after successful payment.
+                   When enabled, the success/invoice screen is bypassed and the
+                   customer is redirected to the merchant return URL immediately
+                   after payment confirmation. Reduces missed callbacks when
+                   customers close the tab thinking the payment is complete. #}
+                <div class="op-form-group">
+                    <label class="op-toggle-label">
+                        <input type="checkbox" name="auto_redirect_to_merchant" value="1" {{ (checkout_settings.auto_redirect_to_merchant ?? '0') == '1' ? 'checked' : '' }}>
+                        <span class="op-toggle-switch"></span>
+                        <span>Auto-redirect to Merchant After Payment</span>
+                    </label>
+                    <small class="op-text-muted op-d-block op-mt-1">When active, the success screen is bypassed and the customer is redirected to the merchant return URL immediately after payment confirmation. Disable to show the invoice/receipt screen with a manual return button.</small>
+                </div>
             </div>
         </div>
 

--- a/templates/admin/transactions/edit.twig
+++ b/templates/admin/transactions/edit.twig
@@ -17,6 +17,7 @@
                 <dt>Net</dt><dd>{{ txn.currency }} {{ txn.net_amount ?? txn.amount }}</dd>
                 <dt>Gateway</dt><dd>{{ txn.gateway_name }}</dd>
                 <dt>Gateway TRX</dt><dd><code>{{ txn.gateway_trx_id ?? '-' }}</code></dd>
+                <dt>Sender Account</dt><dd><code>{{ txn.sender_account ?? '-' }}</code></dd>
                 <dt>Created</dt><dd>{{ txn.created_at }}</dd>
                 <dt>Updated</dt><dd>{{ txn.updated_at ?? '-' }}</dd>
             </dl>

--- a/templates/checkout/checkout-status.twig
+++ b/templates/checkout/checkout-status.twig
@@ -27,8 +27,15 @@
             {% include 'checkout/partials/_expired.twig' %}
         {% endif %}
 
+        {% set show_redirect_block = false %}
         {% if is_intent is defined and is_intent and merchant_redirect_url is defined and merchant_redirect_url %}
-            <div id="countdown-wrapper" class="st-countdown-wrapper" data-redirect-url="{{ merchant_redirect_url }}" data-payment-id="{{ intent_payment_id }}" data-status="{{ intent_status }}">
+            {% set show_redirect_block = true %}
+        {% elseif auto_redirect is defined and auto_redirect and merchant_redirect_url is defined and merchant_redirect_url %}
+            {% set show_redirect_block = true %}
+        {% endif %}
+
+        {% if show_redirect_block %}
+            <div id="countdown-wrapper" class="st-countdown-wrapper" data-redirect-url="{{ merchant_redirect_url }}" data-payment-id="{{ intent_payment_id ?? txn.trx_id ?? '' }}" data-status="{{ intent_status ?? status }}">
                 <div class="st-countdown-container">
                     <svg width="28" height="28" viewBox="0 0 36 36" class="st-countdown-svg">
                         <circle cx="18" cy="18" r="16" fill="none" stroke="var(--cloud)" stroke-width="3.5"></circle>

--- a/templates/checkout/partials/_gateway-tabs.twig
+++ b/templates/checkout/partials/_gateway-tabs.twig
@@ -1,15 +1,34 @@
-{# GATEWAY TABS - Cards / MFS / Net Banking #}
+{# GATEWAY TABS - Cards / MFS / Net Banking
+   Issue #70: hide a tab entirely when no gateways are configured for that
+   category. A merchant who only configured MFS (e.g. bKash) previously saw
+   empty "Cards" and "Net Banking" tabs that confused customers. We render
+   a tab only when its corresponding gateway list is non-empty. When only
+   one category has gateways, the entire tab bar is hidden because there is
+   nothing to switch between. #}
+{% set hasCards = gateways.global|default([]) is not empty %}
+{% set hasMfs = gateways.mfs|default([]) is not empty %}
+{% set hasBank = gateways.bank|default([]) is not empty %}
+{% set tabCount = (hasCards ? 1 : 0) + (hasMfs ? 1 : 0) + (hasBank ? 1 : 0) %}
+
+{% if tabCount > 1 %}
 <div class="ck-tabs ck-fi">
-    <button type="button" class="ck-tab on" data-t="cards" data-action="go-tab" data-tab-name="cards">
+    {% if hasCards %}
+    <button type="button" class="ck-tab {{ hasCards ? 'on' : '' }}" data-t="cards" data-action="go-tab" data-tab-name="cards">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
         {{ lang.cards ?? 'Cards' }}
     </button>
-    <button type="button" class="ck-tab" data-t="mfs" data-action="go-tab" data-tab-name="mfs">
+    {% endif %}
+    {% if hasMfs %}
+    <button type="button" class="ck-tab {{ not hasCards and hasMfs ? 'on' : '' }}" data-t="mfs" data-action="go-tab" data-tab-name="mfs">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
         MFS
     </button>
-    <button type="button" class="ck-tab" data-t="bank" data-action="go-tab" data-tab-name="bank">
+    {% endif %}
+    {% if hasBank %}
+    <button type="button" class="ck-tab {{ not hasCards and not hasMfs and hasBank ? 'on' : '' }}" data-t="bank" data-action="go-tab" data-tab-name="bank">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M3 21h18"/><path d="M3 10h18"/><path d="M5 6l7-3 7 3"/><line x1="4" y1="10" x2="4" y2="21"/><line x1="20" y1="10" x2="20" y2="21"/><line x1="8" y1="14" x2="8" y2="17"/><line x1="12" y1="14" x2="12" y2="17"/><line x1="16" y1="14" x2="16" y2="17"/></svg>
         {{ lang.net_banking ?? 'Net Banking' }}
     </button>
+    {% endif %}
 </div>
+{% endif %}


### PR DESCRIPTION
## Summary

This PR resolves all 30 open issues outside the #99-#116 range (which was already addressed in PR #117). The work is grouped into five logical buckets — SMS pipeline, manual gateway, API/webhook, multi-brand hardening, and UI/UX — with focused, well-commented fixes that follow the existing code conventions (strict types, bcmath for money, TenantScope for brand isolation, PHPDoc on every new method).

## Verification

- **PHPStan level 9**: clean (`composer analyse`)
- **PHPUnit**: 818 tests, 0 failures, 243 skipped (skipped tests require a live MySQL instance; the integration test base class gracefully skips when DB is unreachable)
- **Twig CS Fixer**: 99 files, 0 errors (`composer lint:twig`)

## Issue-by-issue breakdown

### SMS pipeline (9 issues)

| Issue | Bug | File | Fix |
|-------|-----|------|-----|
| #62 | Exact trx_id match path dead because `provider_trx_id` never persisted | `GatewayApiService.php`, `TransactionRepository.php` | On callback completion, persist `$verification['gateway_trx_id']` to `op_transactions.provider_trx_id` via new `persistProviderTrxId()` helper; added `provider_trx_id` to `$fillable` |
| #63 | Duplicate detection drops distinct same-second SMS | `SmsDataRepository.php`, `SmsParserService.php` | `isDuplicate()` now accepts an optional content fingerprint; `SmsParserService` passes `md5($encrypted)` so two distinct messages in the same second are both retained while true replays still dedupe |
| #64 | Null-`received_at` fallback auto-selects latest pending txn | `TransactionRepository.php` | Both `findPendingMatch()` and `findPendingMatchGlobal()` now apply the same ambiguity guard (exactly one candidate) as the timestamped branch |
| #65 | Regex tester reads POST form fields but JS sends JSON | `SmsTemplateAdminController.php` | `testRegex()` uses `Request::input()` which reads POST → JSON → query in priority order, so both caller types work |
| #66 | Saved templates never validated for regex syntax | `SmsTemplateRepository.php`, `SmsTemplateAdminController.php` | New `assertRegexFields()` validates `amount_regex`/`trx_id_regex`/`sender_regex` syntax on `createTemplate()` and `updateTemplate()`; controller catches `InvalidArgumentException` and flashes the error |
| #67 | Test Regex preview doesn't match production | `SmsRegexParser.php`, `SmsTemplateAdminController.php` | New public `SmsRegexParser::testPattern()` runs the regex through `ensureDelimiters()` + `safeMatch()` (bounded backtracking, `/i` modifier) so the preview is representative; `testRegex()` delegates to it |
| #68 | Sender-whitelist check is case-sensitive | `SmartSmsAnalyzer.php` | `checkSenderWhitelist()` now uses `mb_strtolower` comparison, matching the case-insensitive `findBySender()` the rest of the pipeline already uses |
| #69 | `patternToSuggestion()` strips `/u` modifier | `SmartSmsAnalyzer.php` | The `/u` modifier is now preserved when stripping delimiters, so Bengali patterns keep Unicode-aware matching after being saved as a suggestion |
| #39 | SMS regex not match (vague report) | — | Root cause addressed collectively by #65/#66/#67 — the regex tester now works, syntax is validated on save, and the preview matches production behaviour |

### Manual gateway (3 issues)

| Issue | Bug | File | Fix |
|-------|-----|------|-----|
| #56, #48 | Sender number not persisted to `sender_account`; not shown in admin | `CheckoutController.php`, `PaymentIntentCheckoutController.php`, `templates/admin/transactions/edit.twig` | Both `manualVerify()` flows now call `updateScoped(['sender_account' => $senderNumber])` after the metadata write; admin transaction detail template renders `txn.sender_account` |
| #57 | `min_amount`/`max_amount` saved but never enforced | `CheckoutController.php`, `PaymentIntentCheckoutController.php` | New private `validateManualGatewayAmount()` uses `bccomp` to enforce limits in both `pay()` flows; clear error message on violation |
| #58 | Logo and QR code missing on API-initiated checkouts | `PaymentIntentCheckoutController.php` | `manualDetails` payload now includes `logo_path` and `qr_code_path`, mirroring the classic checkout shape |

### API / webhook (3 issues)

| Issue | Bug | File | Fix |
|-------|-----|------|-----|
| #54 | Webhook payload missing payment UUID | `WebhookDispatcher.php` | `buildPayload()` now resolves the intent UUID (from explicit `payment_id` or the `op_payment_intents.uuid` column) and includes it as `payment_id` in the payload |
| #59 | No auto-dispatch on payment completion; no trx→UUID lookup | `WebhookAutoDispatchListener.php` (new), `config/services.php`, `TransactionController.php` | New listener wired to `payment.transaction.completed` at priority 30 forwards the transaction to `WebhookService::dispatch()`; `TransactionController::safeFields()` now exposes `payment_intent_id` |
| #61 | `DisputeService::open()` unreachable | `DisputeController.php`, `config/routes/web.php`, `templates/admin/disputes/index.twig` | New `create()` action + `POST /admin/disputes/create` route + inline toggle form on the disputes index page; verifies the transaction belongs to the active brand before opening |
| #60 | Admin customer table shows internal id instead of trx_id | `templates/admin/customers/show.twig` | One-line template fix: `txn.id` → `txn.trx_id` |

### Multi-brand hardening (8 issues)

| Issue | Concern | File | Fix |
|-------|---------|------|-----|
| #74, #80 | Domain routing case-sensitivity + IDN | `DomainMiddleware.php`, `DomainRepository.php` | Host is lowercased and converted to punycode (when `intl` is available) before lookup; `findByDomain()` uses `LOWER(...) = LOWER(...)` so `Brand.com`/`brand.com`/`BRAND.COM` all resolve to the same record |
| #77 | Cross-brand refund integrity | `LedgerService.php` | `recordRefund()` adds an explicit guard verifying `transaction.merchant_id === $merchantId` before posting the ledger entry — defense-in-depth on top of the existing `findScoped()` scoping |
| #79 | White-label theming XSS | `SettingsController.php` | New `sanitizeBrandCss()` strips `expression()`, `behavior:`, `-moz-binding`, `javascript:` URLs, `@import`, and `<script>` blocks from brand CSS; `custom_js` remains gated by the CSP nonce at render time |
| #73, #75, #76, #78 | Theoretical brand-isolation concerns | — | The existing `TenantScope` trait already enforces per-brand isolation via clone-based `forTenant()`; `requireTenant()` throws on unscoped writes; `forAllTenants()` is reserved for owner-level views. No additional code changes needed — these issues were exploratory and the architecture already addresses them |

### UI/UX (5 issues)

| Issue | Concern | File | Fix |
|-------|---------|------|-----|
| #38 | Brand delete option | — | Already implemented at `POST /admin/brands/{id}/delete` with a confirm dialog and last-brand guard — no change needed |
| #40 | Installer UI mobile issues | `public/assets/css/installer.css` | Added CSS rules to show only one logo variant based on `data-theme`; step indicator shrinks connector lines and circles on small screens and collapses to just the active step on ≤360px viewports to eliminate horizontal scroll |
| #70 | Unconfigured payment tabs remain visible | `templates/checkout/partials/_gateway-tabs.twig` | Tabs are now rendered only when their gateway list is non-empty; the entire tab bar is hidden when only one category has gateways |
| #71 | Auto-redirect to merchant toggle | `SettingsController.php`, `templates/admin/settings/index.twig`, `CheckoutController.php`, `templates/checkout/checkout-status.twig` | New `auto_redirect_to_merchant` checkout setting; when enabled, the success status page runs the existing countdown + redirect flow using the merchant return URL sourced from transaction metadata |
| #72 | "Changes saved" popup on unrelated actions + expiry date z-index | `public/assets/js/admin.js`, `public/assets/css/admin.css` | AJAX form handler no longer intercepts GET forms (which were the main source of false toasts) and supports a `data-no-toast` opt-out attribute for POST forms that don't persist data; date picker popover `z-index` raised from 150 to 500 so it renders above dropdowns, modals, and the notification panel |

## Coding standards

Every change adheres to the project conventions documented in `CONTRIBUTING.md`:

- `declare(strict_types=1);` on the new file
- PHPStan level 9 stays green (no `@phpstan-ignore` suppressions added)
- Money comparisons use `bccomp` with 2-decimal precision, never floats
- Tenant-scoped writes go through `forTenant()` / `updateScoped()`
- Prepared statements only — no string-interpolated SQL
- PHPDoc on every new method, explaining *why* not just *what*
- Comments reference the issue number so reviewers can trace the reasoning

## Test plan

- [ ] CI passes `composer test`, `composer analyse`, `composer lint`
- [ ] Manual: create a manual gateway with min/max limits and verify out-of-range amounts are rejected in both classic and PaymentIntent checkout
- [ ] Manual: complete a payment via the API and verify the webhook payload contains `payment_id`
- [ ] Manual: open the SMS Center → Regex Tester and verify a JSON payload from the JS caller is accepted
- [ ] Manual: save an SMS template with an invalid regex and verify a clear error is shown
- [ ] Manual: view the installer on a mobile viewport and verify only one logo renders, no horizontal scroll
- [ ] Manual: open a brand with only MFS gateways and verify the Card/Bank tabs are hidden
- [ ] Manual: enable `auto_redirect_to_merchant` and verify the success page redirects to the merchant URL

Closes #38, #39, #40, #48, #54, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67, #68, #69, #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80.
