### PR TITLE
fix(security): resolve all 9 CRITICAL audit findings (#121, #173, #174, #198, #237, #238, #239, #257, #274)

### DIFF
--- a/src/Controller/Admin/ApiKeyController.php
+++ b/src/Controller/Admin/ApiKeyController.php
@@ -97,6 +97,22 @@ final class ApiKeyController
             }
         }
 
+        // Security: the 'admin' scope grants unrestricted access to every
+        // /api/v1/admin/* endpoint (AdminBearerAuthMiddleware only checks for
+        // the 'admin' scope string, not for specific permissions). Allowing any
+        // staff member with the 'api_keys.manage' permission to mint an
+        // admin-scoped key would let them self-elevate to full admin-api
+        // control without their role actually holding the underlying
+        // permissions (devices.manage, sms.manage, etc.).
+        // Restrict the 'admin' scope to superadmins only — the same guard that
+        // RolesController::update() applies via $_SESSION['is_superadmin'].
+        // Non-superadmins can still mint read/write keys for routine work.
+        // See audit finding CUS-5 / issue #198.
+        if (in_array('admin', $scopes, true) && !$this->session->isSuperadmin()) {
+            $this->session->flashError('Only superadmins can generate admin-scoped API keys.');
+            return Response::redirect('/admin/developer');
+        }
+
         $key = $this->keys->generate($mid, $label, $scopes);
 
         $_SESSION['_generated_api_key'] = $key['key'];

--- a/src/Controller/Admin/BrandController.php
+++ b/src/Controller/Admin/BrandController.php
@@ -368,7 +368,17 @@ final class BrandController
     }
 
     /**
-     * Removes a brand instance and cascades records via foreign key constraints.
+     * Removes a brand instance.
+     *
+     * Deletion is BLOCKED when the brand has any financial history
+     * (transactions, refunds, disputes, customers, invoices, payment links,
+     * or non-zero ledger balances). This protects the audit trail required by
+     * PCI-DSS requirement 10 (≥1 year retention) and tax-law record-retention
+     * mandates (typically 5–7 years). Brands with no financial activity
+     * (e.g. created in error) can still be deleted.
+     *
+     * See audit finding BRD-1 / issue #237 for the full impact analysis of the
+     * previous unconditional CASCADE delete.
      *
      * @param Request $req The incoming HTTP request.
      *
@@ -399,16 +409,93 @@ final class BrandController
             return Response::redirect('/admin/brands');
         }
 
-        // Hard delete brand + cascade handled by DB FK constraints
+        // Integrity: refuse to delete a brand that has any financial history.
+        // CASCADE deletion would destroy transactions, refunds, double-entry
+        // ledger rows, disputes, customers, invoices, and webhook delivery
+        // logs — violating PCI-DSS, tax-law, and chargeback-defense retention
+        // requirements. The admin must first archive/migrate those records to
+        // a cold-storage table (out of scope for this controller).
         $db = $this->c->get(\OwnPay\Core\Database::class);
-        if ($db instanceof \OwnPay\Core\Database) {
-            $db->execute("DELETE FROM op_merchants WHERE id = :id", ['id' => $id]);
+        if (!$db instanceof \OwnPay\Core\Database) {
+            $this->session->flashError('Database service unavailable; cannot verify brand is safe to delete');
+            return Response::redirect('/admin/brands');
         }
+
+        $blockers = $this->collectDeletionBlockers($db, $id);
+        if (!empty($blockers)) {
+            $brandNameVal = $brand['name'] ?? '';
+            $brandName = is_string($brandNameVal) ? $brandNameVal : '';
+            $this->audit->log('brand.delete_blocked', 'merchant', $id, null, [
+                'name' => $brandName,
+                'blockers' => $blockers,
+            ]);
+            $summary = implode(', ', $blockers);
+            $this->session->flashError(
+                "Cannot delete brand '{$brandName}': it has financial history ({$summary}). "
+                . 'Archive or migrate those records before deletion.'
+            );
+            return Response::redirect('/admin/brands');
+        }
+
+        // No financial history — safe to hard-delete. Cascade handled by DB FK constraints.
+        $db->execute("DELETE FROM op_merchants WHERE id = :id", ['id' => $id]);
 
         $brandNameVal = $brand['name'] ?? '';
         $brandName = is_string($brandNameVal) ? $brandNameVal : '';
         $this->audit->log('brand.deleted', 'merchant', $id, ['name' => $brandName]);
         $this->session->flashSuccess("Brand '{$brandName}' deleted");
         return Response::redirect('/admin/brands');
+    }
+
+    /**
+     * Collects the list of financial-history blockers that prevent brand deletion.
+     *
+     * Returns a non-empty array of human-readable blocker descriptions when the
+     * brand has any dependent financial records. Returns an empty array when the
+     * brand is safe to hard-delete.
+     *
+     * @param \OwnPay\Core\Database $db The database wrapper.
+     * @param int $id The merchant/brand ID.
+     * @return list<string> List of blocker descriptions; empty when safe to delete.
+     */
+    private function collectDeletionBlockers(\OwnPay\Core\Database $db, int $id): array
+    {
+        $checks = [
+            ['op_transactions', 'transactions'],
+            ['op_refunds', 'refunds'],
+            ['op_disputes', 'disputes'],
+            ['op_invoices', 'invoices'],
+            ['op_payment_links', 'payment links'],
+            ['op_payment_intents', 'payment intents'],
+            ['op_customers', 'customers'],
+            ['op_webhooks', 'webhook deliveries'],
+            ['op_api_keys', 'API keys'],
+            ['op_merchant_users', 'staff accounts'],
+            ['op_fee_rules', 'fee rules'],
+        ];
+
+        $blockers = [];
+        foreach ($checks as [$table, $label]) {
+            $count = $db->fetchOne("SELECT COUNT(*) AS c FROM {$table} WHERE merchant_id = :mid", ['mid' => $id]);
+            $countVal = $count['c'] ?? 0;
+            $countInt = is_numeric($countVal) ? (int) $countVal : 0;
+            if ($countInt > 0) {
+                $blockers[] = "{$countInt} {$label}";
+            }
+        }
+
+        // Non-zero ledger account balances would silently disappear under CASCADE
+        // delete, so they get their own explicit check.
+        $balances = $db->fetchOne(
+            "SELECT COALESCE(SUM(balance), 0) AS total FROM op_ledger_accounts WHERE merchant_id = :mid",
+            ['mid' => $id]
+        );
+        $totalVal = $balances['total'] ?? 0;
+        $totalStr = is_numeric($totalVal) ? (string) $totalVal : '0';
+        if (bccomp($totalStr, '0', 2) !== 0) {
+            $blockers[] = "non-zero ledger balance ({$totalStr})";
+        }
+
+        return $blockers;
     }
 }

--- a/src/Controller/Admin/DomainController.php
+++ b/src/Controller/Admin/DomainController.php
@@ -326,11 +326,23 @@ final class DomainController
             $redirectUrl = null;
         }
 
-        $statusVal = $req->post('status', 'pending');
-        $status = is_string($statusVal) && in_array($statusVal, ['active', 'pending', 'inactive'], true) ? $statusVal : 'pending';
-
-        $dnsVerifiedVal = $req->post('dns_verified', '0');
-        $dnsVerified = (is_scalar($dnsVerifiedVal) && (int) $dnsVerifiedVal === 1) ? 1 : 0;
+        // Security (audit finding DOM-1 / issue #239): `dns_verified` and
+        // `status` are intentionally NOT read from the POST body. The previous
+        // implementation accepted both fields from the form and persisted them
+        // directly, allowing a brand admin (or an attacker via BRD-2) to mark
+        // any domain — including an unverified, attacker-controlled domain — as
+        // fully verified and active with a single POST. This completely
+        // defeated the domain-ownership security model that DomainService::verify()
+        // enforces via actual TXT/A DNS lookups.
+        //
+        // DNS verification status now ONLY changes via DomainService::verify()
+        // (invoked through the /admin/domains/{id}/verify endpoint). Domain
+        // status ('active'/'pending'/'inactive') is managed internally by the
+        // verification flow and cannot be set directly by the caller. The
+        // update endpoint only modifies `type` and `redirect_url`.
+        //
+        // Existing `dns_verified` and `status` values are preserved because
+        // updateScoped() only writes the keys present in $updateData.
 
         $isPrimaryVal = $req->post('is_primary', '0');
         $isPrimary = (is_scalar($isPrimaryVal) && (int) $isPrimaryVal === 1) ? 1 : 0;
@@ -338,8 +350,6 @@ final class DomainController
         $updateData = [
             'type'         => $type,
             'redirect_url' => $redirectUrl,
-            'status'       => $status,
-            'dns_verified' => $dnsVerified,
         ];
 
         // Handles toggling primary status

--- a/src/Controller/Admin/TransactionController.php
+++ b/src/Controller/Admin/TransactionController.php
@@ -14,7 +14,6 @@ use OwnPay\Repository\AuditLogRepository;
 use OwnPay\Service\System\PaginationService;
 use OwnPay\Service\System\AuditService;
 use OwnPay\Event\EventManager;
-use OwnPay\Support\DateHelper;
 
 /**
  * Controller for managing payment transactions within the admin portal.
@@ -59,11 +58,6 @@ final class TransactionController
     private AuditService $audit;
 
     /**
-     * The database wrapper.
-     */
-    private \OwnPay\Core\Database $db;
-
-    /**
      * TransactionController constructor.
      *
      * @param Container $c The dependency injection container.
@@ -81,8 +75,7 @@ final class TransactionController
         SmsParsedRepository $smsRepo,
         AuditLogRepository $auditRepo,
         EventManager $events,
-        AuditService $audit,
-        \OwnPay\Core\Database $db
+        AuditService $audit
     ) {
         $this->c         = $c;
         $this->session   = $session;
@@ -91,7 +84,6 @@ final class TransactionController
         $this->auditRepo = $auditRepo;
         $this->events    = $events;
         $this->audit     = $audit;
-        $this->db        = $db;
     }
 
     /**
@@ -232,7 +224,23 @@ final class TransactionController
     }
 
     /**
-     * Update status of a transaction (e.g. mark completed, refund, cancel) and post double-entry ledger lines.
+     * Update status of a transaction (e.g. mark completed, cancel) and post double-entry ledger lines.
+     *
+     * Refunds are intentionally NOT handled here. The refund flow must go through
+     * `RefundController::store` → `RefundService::create`, which enforces:
+     *   - SELECT ... FOR UPDATE on the transaction row
+     *   - Sum of prior refunds cannot exceed the original amount
+     *   - Merchant payable ledger balance is sufficient net of pending refunds
+     *   - Gateway refund API is invoked
+     *   - Transaction status flips to 'refunded' only when the total refunded
+     *     equals the original amount (not on any partial refund)
+     *
+     * The previous implementation accepted `status=refunded` here and posted a
+     * full-amount refund ledger entry unconditionally, bypassing every one of
+     * the guards above. Among other things, this allowed over-refund (because
+     * the SUM(amount) cap was never checked) and posted ledger entries even
+     * when partial refunds already existed, permanently unbalancing the books.
+     * See audit finding PAY-1 / issue #173 for the full impact analysis.
      *
      * @param Request $req The incoming HTTP request.
      * @return Response The HTTP redirect response.
@@ -245,8 +253,8 @@ final class TransactionController
         $mid = $this->resolveMerchant($req);
 
         $newStatus = $req->post('status', '');
-        if (!in_array($newStatus, ['completed', 'canceled', 'refunded'], true)) {
-            $this->session->flashError('Invalid status');
+        if (!in_array($newStatus, ['completed', 'canceled'], true)) {
+            $this->session->flashError('Invalid status. Refunds must be processed via the refund form.');
             return Response::redirect("/admin/transactions/{$id}");
         }
 
@@ -266,18 +274,15 @@ final class TransactionController
         }
 
         // State machine enforcement: terminal transactions must not be
-        // re-completed or cancelled, and only completed transactions may be
-        // marked refunded - otherwise ledger entries get posted for money
-        // that never moved (e.g. "refunding" a failed payment).
+        // re-completed or cancelled, otherwise ledger entries get posted for
+        // money that never moved (e.g. "completing" an already-refunded payment).
+        // $newStatus is already narrowed to 'completed'|'canceled' by the
+        // whitelist guard above, so only the terminal-state check remains.
         $currentStatus = isset($txn['status']) && is_scalar($txn['status']) ? (string) $txn['status'] : '';
         $terminalStatuses = array_map(static fn(TransactionStatus $s) => $s->value, TransactionStatus::terminal());
 
-        if (in_array($newStatus, ['completed', 'canceled'], true) && in_array($currentStatus, $terminalStatuses, true)) {
+        if (in_array($currentStatus, $terminalStatuses, true)) {
             $this->session->flashError("Cannot mark a {$currentStatus} transaction as {$newStatus}");
-            return Response::redirect("/admin/transactions/{$id}");
-        }
-        if ($newStatus === 'refunded' && $currentStatus !== 'completed') {
-            $this->session->flashError('Only completed transactions can be marked refunded');
             return Response::redirect("/admin/transactions/{$id}");
         }
 
@@ -308,42 +313,6 @@ final class TransactionController
                     is_string($currencyVal) ? $currencyVal : 'BDT'
                 );
             }
-        } elseif ($newStatus === 'refunded') {
-            $this->txns->forTenant($mid)->updateScoped($id, ['status' => 'refunded', 'updated_at' => DateHelper::now()]);
-            $amountVal = $txn['amount'] ?? '0.00';
-            $currencyVal = $txn['currency'] ?? 'BDT';
-            $amount = is_string($amountVal) ? $amountVal : '0.00';
-
-            // Find or create a refund record in op_refunds to get a unique refund ID for the ledger
-            $refundRepo = $this->db->fetchOne(
-                "SELECT id FROM op_refunds WHERE transaction_id = :txid AND merchant_id = :mid AND amount = :amt LIMIT 1",
-                ['txid' => $id, 'mid' => $mid, 'amt' => $amount]
-            );
-
-            if ($refundRepo !== null && isset($refundRepo['id'])) {
-                $idVal = $refundRepo['id'];
-                $refundId = is_scalar($idVal) ? (int) $idVal : 0;
-                $this->db->execute(
-                    "UPDATE op_refunds SET status = 'completed', processed_at = NOW() WHERE id = :id",
-                    ['id' => $refundId]
-                );
-            } else {
-                $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
-                $this->db->execute(
-                    "INSERT INTO op_refunds (merchant_id, transaction_id, uuid, amount, reason, status, processed_at)
-                     VALUES (:mid, :txid, :uuid, :amt, 'Refund processed by administrator', 'completed', NOW())",
-                    ['mid' => $mid, 'txid' => $id, 'uuid' => $uuid, 'amt' => $amount]
-                );
-                $refundId = (int) $this->db->lastInsertId();
-            }
-
-            $ledgerService->recordRefund(
-                $mid,
-                $refundId,
-                $id,
-                $amount,
-                is_string($currencyVal) ? $currencyVal : 'BDT'
-            );
         } elseif ($newStatus === 'canceled') {
             $transactionService->cancel($id, $mid);
         }

--- a/src/Controller/Admin/TwoFactorSetupController.php
+++ b/src/Controller/Admin/TwoFactorSetupController.php
@@ -69,7 +69,7 @@ final class TwoFactorSetupController
         // Use decrypted secret for QR code, not raw encrypted column.
         $secret  = $this->userRepo->getTotpSecret($userId);
         $enabled = (bool) ($user['two_factor_enabled'] ?? false);
-        $qrUri   = null;
+        $qrDataUri = null;
 
         if (!$enabled) {
             if (empty($secret)) {
@@ -82,15 +82,57 @@ final class TwoFactorSetupController
             $userEmail = is_string($user['email'] ?? null) ? $user['email'] : '';
             $email   = rawurlencode($userEmail);
             $qrUri   = "otpauth://totp/{$appName}:{$email}?secret={$secret}&issuer={$appName}&algorithm=SHA1&digits=6&period=30";
+
+            // Security (audit finding UI-3 / issue #274): render the QR code
+            // server-side via chillerlan/php-qrcode (already a composer dep)
+            // and pass ONLY the resulting data URI to the template. The raw
+            // otpauth:// URI — which contains the TOTP shared secret in
+            // cleartext — must NEVER be sent to a third-party service or
+            // exposed to the template layer, where a future template change
+            // could accidentally render it. The previous implementation loaded
+            // the QR image from https://api.qrserver.com/v1/create-qr-code/
+            // with the otpauth:// URI as a query parameter, leaking the secret
+            // to a third-party domain and giving anyone compromising that
+            // service persistent 2FA-code-generation capability.
+            $qrDataUri = $this->renderQrDataUri($qrUri);
         }
 
         return $this->renderAdminPage('admin/my-account-2fa.twig', [
-            'user'        => $user,
-            'totp_secret' => $secret,
-            'totp_enabled'=> $enabled,
-            'qr_uri'      => $qrUri,
-            'active_page' => 'profile',
+            'user'         => $user,
+            'totp_secret'  => $secret,
+            'totp_enabled' => $enabled,
+            'qr_data_uri'  => $qrDataUri,
+            'active_page'  => 'profile',
         ]);
+    }
+
+    /**
+     * Renders an otpauth:// URI as an inline SVG data URI using chillerlan/php-qrcode.
+     *
+     * The returned string is a `data:image/svg+xml;base64,...` URI that can be
+     * used directly as an <img src> attribute. No network request is made —
+     * the QR code is rendered entirely server-side, so the TOTP secret never
+     * leaves the OwnPay server.
+     *
+     * @param string $otpauthUri The otpauth:// URI to encode as a QR code.
+     * @return string|null The data URI, or null if rendering fails (the template
+     *                     gracefully falls back to displaying the manual-entry
+     *                     secret code).
+     */
+    private function renderQrDataUri(string $otpauthUri): ?string
+    {
+        try {
+            $options = new \chillerlan\QRCode\QROptions([
+                'outputType'  => \chillerlan\QRCode\QRCode::OUTPUT_MARKUP_SVG,
+                'scale'       => 5,
+                'cssClass'    => 'op-qr-img',
+                'outputBase64' => true,
+            ]);
+            $rendered = (new \chillerlan\QRCode\QRCode($options))->render($otpauthUri);
+            return is_string($rendered) ? $rendered : null;
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Controller/Api/ApiKeyController.php
+++ b/src/Controller/Api/ApiKeyController.php
@@ -152,7 +152,20 @@ final class ApiKeyController
     }
 
     /**
-     * Enforce write and admin scopes and active super admin email header validation.
+     * Enforce that the caller's API key carries both `write` and `admin` scopes.
+     *
+     * The caller's identity is cryptographically bound to the API key (verified
+     * by BearerAuthMiddleware via SHA-256 + hash_equals). Scope enforcement here
+     * is sufficient to gate super-admin-gated operations: a key with `admin`
+     * scope can only have been issued by the merchant's own superadmin via the
+     * web admin UI (or another `admin`-scoped key they already control).
+     *
+     * Prior versions of this method also accepted an `X-Super-Admin-Email`
+     * request header. That header was pure security theater — it only verified
+     * that the supplied email belonged to *some* superadmin record (public
+     * information), without any proof that the caller was that superadmin. Any
+     * merchant holding an `admin`-scoped key could spoof any known superadmin
+     * email to pass the check. The header has been removed.
      *
      * @param Request $req The incoming HTTP request.
      * @return Response|null Response error if unauthorized, otherwise null.
@@ -178,21 +191,6 @@ final class ApiKeyController
 
         if (!in_array('write', $scopes, true) || !in_array('admin', $scopes, true)) {
             return Response::apiError('INSUFFICIENT_PRIVILEGE', 'Insufficient API key privilege. Key must have both write and admin scopes.', null, 403);
-        }
-
-        $email = trim($req->header('X-Super-Admin-Email'));
-        if ($email === '') {
-            return Response::apiError('SUPER_ADMIN_EMAIL_REQUIRED', 'Super admin email is required in the X-Super-Admin-Email header.', 'X-Super-Admin-Email', 400);
-        }
-
-        $db = \OwnPay\Core\Database::getInstance();
-        $user = $db->fetchOne(
-            "SELECT 1 FROM op_merchant_users WHERE email = :email AND is_superadmin = 1 AND status = 'active' LIMIT 1",
-            ['email' => $email]
-        );
-
-        if (!$user) {
-            return Response::apiError('INVALID_SUPER_ADMIN', 'Invalid or inactive super admin email in header.', 'X-Super-Admin-Email', 403);
         }
 
         return null;

--- a/src/Controller/Checkout/PaymentLinkCheckoutController.php
+++ b/src/Controller/Checkout/PaymentLinkCheckoutController.php
@@ -221,6 +221,22 @@ final class PaymentLinkCheckoutController
             $brandCtx->setActiveBrandId($merchantId);
         }
 
+        // Security: fixed-amount links must never accept a customer-supplied
+        // amount via POST. The `show()` flow creates the transaction directly
+        // with the stored amount and never renders the amount-entry form, so a
+        // POST to /submit for a fixed-amount link is always an attempt to
+        // tamper with the charged amount (see audit finding PAY-2 / issue #174).
+        // Reject the request outright; do not fall through to amount validation
+        // (which would otherwise accept amount=1 for a $100 fixed link when no
+        // min_amount is configured). The schema column `is_amount_fixed` is a
+        // TINYINT(1) that defaults to 1, so a missing value is treated as fixed.
+        $isFixedRaw = $link['is_amount_fixed'] ?? 1;
+        $isFixed = (is_int($isFixedRaw) || is_string($isFixedRaw) || is_bool($isFixedRaw))
+            && (int) $isFixedRaw === 1;
+        if ($isFixed) {
+            return $this->renderExpired($brandId);
+        }
+
         $amountRaw = $req->post('amount', '0');
         $amountStr = is_string($amountRaw) ? $amountRaw : '0';
         if (!is_numeric($amountStr)) {

--- a/src/Middleware/PermissionMiddleware.php
+++ b/src/Middleware/PermissionMiddleware.php
@@ -55,6 +55,58 @@ final class PermissionMiddleware
         if ($brandCtx instanceof \OwnPay\Service\Brand\BrandContext) {
             $brandCtx->resolveFromRequest($request);
             $activeBrandId = $brandCtx->getActiveBrandId();
+
+            // Security: cross-brand privilege-escalation guard (audit finding
+            // BRD-2 / issue #238). Public checkout controllers call
+            // BrandContext::setActiveBrandId($mid) to set the rendering brand
+            // context, which writes $mid into $_SESSION['active_brand_id']. If
+            // a non-superadmin brand-A staff member visits a public checkout
+            // URL for brand B (on the master domain, where DomainMiddleware
+            // does not set the merchant_id request attribute), their session's
+            // active_brand_id is silently overwritten to brand B — and every
+            // subsequent /admin/* request is then scoped to brand B, leaking
+            // cross-brand data.
+            //
+            // BrandController::switchBrand already enforces that non-superadmins
+            // can only switch to their own auth_merchant_id. This middleware
+            // enforces the same invariant on every /admin/* request: if the
+            // active_brand_id does not match the caller's auth_merchant_id (and
+            // the caller is not a superadmin), reset the session back to the
+            // caller's home brand, log the event to the audit trail, and flash
+            // a security warning.
+            //
+            // This check runs BEFORE the global-only-route block below so that
+            // a poisoned session is reset on the first /admin/* request rather
+            // than after a misleading "only accessible in Global View" redirect.
+            if ($activeBrandId !== null && $activeBrandId > 0 && session_status() === PHP_SESSION_ACTIVE) {
+                $authMerchantIdVal = $_SESSION['auth_merchant_id'] ?? null;
+                $authMerchantId = is_scalar($authMerchantIdVal) ? (int) $authMerchantIdVal : 0;
+                $isSuperadmin = !empty($_SESSION['is_superadmin']);
+                if (!$isSuperadmin && $authMerchantId > 0 && $activeBrandId !== $authMerchantId) {
+                    $userId = is_scalar($userId) ? (int) $userId : null;
+                    $audit = $this->container->get(\OwnPay\Service\System\AuditService::class);
+                    if ($audit instanceof \OwnPay\Service\System\AuditService) {
+                        $audit->log(
+                            'security.brand_context_reset',
+                            'session',
+                            $userId,
+                            ['active_brand_id' => $activeBrandId],
+                            ['active_brand_id' => $authMerchantId]
+                        );
+                    }
+                    // Reset to the caller's legitimate home brand.
+                    $brandCtx->setActiveBrandId($authMerchantId);
+                    $session = $this->container->get(\OwnPay\Service\Admin\AdminSession::class);
+                    if ($session instanceof \OwnPay\Service\Admin\AdminSession) {
+                        $session->flashError('Brand context was reset to your home brand due to a security check.');
+                    }
+                    if ($request->expectsJson()) {
+                        return Response::json(['success' => false, 'message' => 'Brand context was reset to your home brand due to a security check.'], 403);
+                    }
+                    return Response::redirect('/admin');
+                }
+            }
+
             if ($activeBrandId !== null && $activeBrandId > 0) {
                 $path = $request->path();
                 $globalOnlyPrefixes = [
@@ -64,7 +116,7 @@ final class PermissionMiddleware
                     '/admin/balance-verification',
                     '/admin/audit-integrity',
                 ];
-                
+
                 if ($path !== '/admin/brands/switch') {
                     foreach ($globalOnlyPrefixes as $prefix) {
                         if ($path === $prefix || str_starts_with($path, $prefix . '/')) {

--- a/src/View/TwigExtensions.php
+++ b/src/View/TwigExtensions.php
@@ -57,7 +57,6 @@ final class TwigExtensions extends AbstractExtension
             new TwigFunction('csrf_token', [$this, 'csrfToken'], ['is_safe' => ['html']]),
             new TwigFunction('csrf_field', [$this, 'csrfField'], ['is_safe' => ['html']]),
             new TwigFunction('asset', [$this, 'asset']),
-            new TwigFunction('env', [$this, 'env']),
             new TwigFunction('hook', [$this, 'hook'], ['is_safe' => ['html']]),
             new TwigFunction('hook_filter', [$this, 'hookFilter']),
             new TwigFunction('app_name', [$this, 'appName']),
@@ -131,18 +130,6 @@ final class TwigExtensions extends AbstractExtension
         }
         $cleanPath = ltrim($path, '/');
         return '/assets/' . $cleanPath . '?v=' . $version;
-    }
-
-    /**
-     * Fetch a key from environment configuration variables.
-     *
-     * @param string $key The key name of the environment variable.
-     * @param string $default The fallback value if key does not exist.
-     * @return string The configuration value or its default fallback.
-     */
-    public function env(string $key, string $default = ''): string
-    {
-        return (string) (getenv($key) ?: $default);
     }
 
     /**

--- a/templates/admin/brands/index.twig
+++ b/templates/admin/brands/index.twig
@@ -24,7 +24,7 @@
                     <td data-label="Actions" class="op-nowrap">
                         <a href="/admin/brands/{{ m.id }}" class="op-btn op-btn-xs op-btn-outline">Edit</a>
                         {% if brand_list|length > 1 %}
-                        <form method="POST" action="/admin/brands/{{ m.id }}/delete" class="op-inline-form" onsubmit="return confirm('⚠️ DELETE brand \'{{ m.name|e('js') }}\'? This removes ALL associated data (transactions, customers, gateways). This action is IRREVERSIBLE.')">
+                        <form method="POST" action="/admin/brands/{{ m.id }}/delete" class="op-inline-form" onsubmit="return confirm('Delete brand \'{{ m.name|e('js') }}\'? Deletion is blocked if this brand has any financial history (transactions, refunds, disputes, customers, invoices, etc.). Brands with no financial activity can be deleted permanently.')">
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="op-btn op-btn-xs op-btn-danger">Delete</button>
                         </form>

--- a/templates/admin/domains/_manage-panel.twig
+++ b/templates/admin/domains/_manage-panel.twig
@@ -18,8 +18,6 @@
 
         <form method="POST" action="/admin/domains/{{ d.id }}/update" class="op-domain-inline-form" data-no-ajax data-domain-inline-update="{{ d.id }}">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-            <input type="hidden" name="status" value="{{ d.status }}">
-            <input type="hidden" name="dns_verified" value="{{ d.dns_verified ? '1' : '0' }}">
             <input type="hidden" name="is_primary" value="{{ d.is_primary ? '1' : '0' }}">
             <div class="op-form-group">
                 <label>Domain Type</label>

--- a/templates/admin/my-account-2fa.twig
+++ b/templates/admin/my-account-2fa.twig
@@ -41,8 +41,12 @@
                 <h4>Step 1 - Scan QR Code</h4>
                 <p class="op-text-muted">Open your authenticator app (Google Authenticator, Authy, etc.) and scan this QR code.</p>
                 <div class="op-2fa-qr op-2fa-qr-container">
-                    <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data={{ qr_uri|url_encode }}"
+                    {% if qr_data_uri %}
+                    <img src="{{ qr_data_uri }}"
                           alt="2FA QR Code" width="200" height="200" class="op-qr-img">
+                    {% else %}
+                    <p class="op-text-muted">QR code could not be rendered. Please enter the code manually below.</p>
+                    {% endif %}
                 </div>
                 <details class="op-mt-2">
                     <summary class="op-text-muted op-cursor-pointer op-details-summary">Can't scan? Enter this code manually</summary>

--- a/tests/Integration/ApiKeyApiSecurityTest.php
+++ b/tests/Integration/ApiKeyApiSecurityTest.php
@@ -103,9 +103,10 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         return $this->db->fetchOne("SELECT * FROM op_api_keys WHERE key_prefix = :p", ['p' => $prefix]);
     }
 
-    public function testIndexRequiresWriteAdminScopesAndValidSuperAdminHeader(): void
+    public function testIndexRequiresWriteAdminScopes(): void
     {
-        $req1 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail]);
+        // A standard (read+write only) key must be rejected with 403.
+        $req1 = new Request([], [], []);
         $req1->setAttribute('merchant_id', 99996);
         $req1->setAttribute('api_key', $this->getCallerKeyRow($this->standardKey));
 
@@ -115,34 +116,10 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         $this->assertFalse($body1['success']);
         $this->assertSame('INSUFFICIENT_PRIVILEGE', $body1['errors'][0]['code']);
 
-        $req2 = new Request([], [], []);
-        $req2->setAttribute('merchant_id', 99996);
-        $req2->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
-
-        $res2 = $this->controller->index($req2);
-        $this->assertSame(400, $res2->getStatusCode());
-        $body2 = json_decode($res2->getBody(), true);
-        $this->assertSame('SUPER_ADMIN_EMAIL_REQUIRED', $body2['errors'][0]['code']);
-
-        $req3 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->nonAdminEmail]);
-        $req3->setAttribute('merchant_id', 99996);
-        $req3->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
-
-        $res3 = $this->controller->index($req3);
-        $this->assertSame(403, $res3->getStatusCode());
-        $body3 = json_decode($res3->getBody(), true);
-        $this->assertSame('INVALID_SUPER_ADMIN', $body3['errors'][0]['code']);
-
-        $req4 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->inactiveSuperAdminEmail]);
-        $req4->setAttribute('merchant_id', 99996);
-        $req4->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
-
-        $res4 = $this->controller->index($req4);
-        $this->assertSame(403, $res4->getStatusCode());
-        $body4 = json_decode($res4->getBody(), true);
-        $this->assertSame('INVALID_SUPER_ADMIN', $body4['errors'][0]['code']);
-
-        $req5 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail]);
+        // An admin-scoped key (without any spoofed header) must succeed — the
+        // X-Super-Admin-Email header was removed as part of the API-1 security
+        // fix (it was pure security theater, providing no real identity proof).
+        $req5 = new Request([], [], []);
         $req5->setAttribute('merchant_id', 99996);
         $req5->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
@@ -155,7 +132,7 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
 
     public function testGenerateParsesAndValidatesCustomScopes(): void
     {
-        $req1 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail], [], [], '{"scopes": "not-an-array"}');
+        $req1 = new Request([], [], [], [], [], '{"scopes": "not-an-array"}');
         $req1->setAttribute('merchant_id', 99996);
         $req1->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
@@ -165,21 +142,21 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         $this->assertFalse($body1['success']);
         $this->assertSame('INVALID_SCOPES', $body1['errors'][0]['code']);
 
-        $req2 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail], [], [], '{"scopes": ["read", "invalid_privilege"]}');
+        $req2 = new Request([], [], [], [], [], '{"scopes": ["read", "invalid_privilege"]}');
         $req2->setAttribute('merchant_id', 99996);
         $req2->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
         $res2 = $this->controller->generate($req2);
         $this->assertSame(422, $res2->getStatusCode());
 
-        $req3 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail], [], [], '{"scopes": []}');
+        $req3 = new Request([], [], [], [], [], '{"scopes": []}');
         $req3->setAttribute('merchant_id', 99996);
         $req3->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
         $res3 = $this->controller->generate($req3);
         $this->assertSame(422, $res3->getStatusCode());
 
-        $req4 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail], [], [], '{}');
+        $req4 = new Request([], [], [], [], [], '{}');
         $req4->setAttribute('merchant_id', 99996);
         $req4->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
@@ -192,7 +169,7 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         $this->assertNotNull($keyRecord4);
         $this->assertEquals(['read', 'write'], json_decode($keyRecord4['scopes'], true));
 
-        $req5 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail], [], [], '{"name": "Custom Scope Key", "scopes": ["read", "admin"]}');
+        $req5 = new Request([], [], [], [], [], '{"name": "Custom Scope Key", "scopes": ["read", "admin"]}');
         $req5->setAttribute('merchant_id', 99996);
         $req5->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
 
@@ -206,12 +183,13 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         $this->assertEquals(['read', 'admin'], json_decode($keyRecord5['scopes'], true));
     }
 
-    public function testRevokeRequiresWriteAdminScopesAndValidSuperAdminHeader(): void
+    public function testRevokeRequiresWriteAdminScopes(): void
     {
         $callerRow = $this->getCallerKeyRow($this->standardKey);
         $keyId = (int) $callerRow['id'];
 
-        $req1 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail]);
+        // Standard (read+write only) key cannot revoke.
+        $req1 = new Request([], [], []);
         $req1->setAttribute('merchant_id', 99996);
         $req1->setAttribute('api_key', $this->getCallerKeyRow($this->standardKey));
         $req1->setRouteParams(['id' => (string) $keyId]);
@@ -219,7 +197,8 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         $res1 = $this->controller->revoke($req1);
         $this->assertSame(403, $res1->getStatusCode());
 
-        $req2 = new Request([], [], ['HTTP_X_SUPER_ADMIN_EMAIL' => $this->superAdminEmail]);
+        // Admin-scoped key can revoke (no spoofed header needed).
+        $req2 = new Request([], [], []);
         $req2->setAttribute('merchant_id', 99996);
         $req2->setAttribute('api_key', $this->getCallerKeyRow($this->adminKey));
         $req2->setRouteParams(['id' => (string) $keyId]);

--- a/tests/Integration/ApiKeyApiSecurityTest.php
+++ b/tests/Integration/ApiKeyApiSecurityTest.php
@@ -220,6 +220,8 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
         }
+        // Issue #198: only superadmins may mint admin-scoped API keys.
+        $_SESSION['is_superadmin'] = true;
         $res = $adminController->generate($req);
 
         $this->assertSame(302, $res->getStatusCode());
@@ -244,12 +246,43 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
             session_start();
         }
         unset($_SESSION['_generated_api_key'], $_SESSION['flash_error']);
+        // Issue #198: only superadmins may mint admin-scoped API keys.
+        $_SESSION['is_superadmin'] = true;
         $res = $adminController->generate($req);
 
         $this->assertSame(302, $res->getStatusCode());
         $this->assertSame('/admin/developer', $res->getHeaders()['Location'] ?? null);
         $this->assertNotEmpty($_SESSION['_generated_api_key'] ?? null, 'A platform-owned key should be generated');
         $this->assertNull($_SESSION['flash_error'] ?? null, 'No "select a brand" error in All Brands view');
+    }
+
+    /**
+     * Regression test for issue #198: a non-superadmin staff member with
+     * api_keys.manage permission must NOT be able to mint an admin-scoped key.
+     * Verifies the privilege-escalation guard added in the fix for #198.
+     */
+    public function testNonSuperadminCannotGenerateAdminScopedKey(): void
+    {
+        $adminController = $this->container->get(\OwnPay\Controller\Admin\ApiKeyController::class);
+
+        $req = new Request([], ['label' => 'Escalation Attempt', 'scopes' => ['read', 'write', 'admin']]);
+        $req->setAttribute('merchant_id', 99996);
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        unset($_SESSION['_generated_api_key'], $_SESSION['_generated_api_key_label'], $_SESSION['flash_error']);
+        // Non-superadmin: the very scenario the guard must reject.
+        $_SESSION['is_superadmin'] = false;
+        $res = $adminController->generate($req);
+
+        $this->assertSame(302, $res->getStatusCode());
+        $this->assertSame('/admin/developer', $res->getHeaders()['Location'] ?? null);
+        $this->assertNull($_SESSION['_generated_api_key'] ?? null, 'No key must be issued to a non-superadmin requesting admin scope');
+        $this->assertNotEmpty($_SESSION['flash_error'] ?? null, 'A flash error must surface explaining the denial');
+
+        $keyRecord = $this->db->fetchOne("SELECT * FROM op_api_keys WHERE name = 'Escalation Attempt' ORDER BY id DESC LIMIT 1");
+        $this->assertNull($keyRecord, 'No DB row must be created for a denied admin-scope request');
     }
 
     public function testAdminRevokeInGlobalViewTargetsPlatformKeys(): void


### PR DESCRIPTION
## Summary

Fixes all 9 CRITICAL security findings from the comprehensive codebase audit.

Each fix was applied one at a time with the workflow: **fix → PHPStan level 9 → commit**. All 9 commits cleanly pass `php vendor/bin/phpstan analyse --level=9 --no-progress` (0 errors).

## Issues Fixed

| # | Issue | Severity | One-line fix |
|---|-------|----------|--------------|
| #121 | Super-admin auth bypass via spoofable `X-Super-Admin-Email` header | CRITICAL | Removed the header check entirely from API key endpoints. Identity is already cryptographically bound to the API key via SHA-256 + `hash_equals` in `BearerAuthMiddleware`; the `admin` scope is only issued by the merchant's own superadmin via the web admin UI. |
| #173 | Admin "mark refunded" bypassing `RefundService` | CRITICAL | Removed `refunded` from the accepted status whitelist on `TransactionController::updateStatus`; deleted the `elseif` branch that posted raw ledger entries and inserted fake refund records. Refunds now must go through `RefundController::store` → `RefundService::create`, which enforces `SELECT … FOR UPDATE`, sum-of-prior-refunds cap, merchant balance check, gateway refund API call, and status flip only when total refunded equals original amount. |
| #174 | Payment link amount tampering | CRITICAL | Added an early-return guard at the top of `PaymentLinkCheckoutController::submit()` that rejects any POST when `is_amount_fixed` is truthy. A legitimate customer never arrives at `submit()` for a fixed-amount link (the `show()` flow already creates the transaction directly with the stored amount and never renders the amount-entry form), so any such POST is an attempted tampering. |
| #198 | Admin-scope self-elevation | CRITICAL | Added the same guard that `RolesController::update()` already uses: if `admin` is in the requested `scopes` AND the caller is not a superadmin (`AdminSession::isSuperadmin()`), flash an error and redirect back without creating the key. Non-superadmins can still mint `read`/`write`-scoped keys for routine work. |
| #237 | Brand hard-delete destroying audit trail | CRITICAL | Added `collectDeletionBlockers()` pre-check that counts rows in 11 dependent tables (`op_transactions`, `op_refunds`, `op_disputes`, `op_invoices`, `op_payment_links`, `op_payment_intents`, `op_customers`, `op_webhooks`, `op_api_keys`, `op_merchant_users`, `op_fee_rules`) and verifies `SUM(balance) = 0` on `op_ledger_accounts`. If any blocker is found, deletion is refused with a descriptive flash error and the attempt is logged to the audit trail as `brand.delete_blocked`. Brands with no financial history can still be deleted — the legitimate use case is preserved. |
| #238 | Cross-brand privilege escalation via `BrandContext::setActiveBrandId` | CRITICAL | Added a cross-brand privilege-escalation guard to `PermissionMiddleware::handle()` that runs on every `/admin/*` request. For non-superadmins, when `active_brand_id > 0` and does not match the caller's `auth_merchant_id`, the middleware logs the event to the audit trail as `security.brand_context_reset`, resets `active_brand_id` back to `auth_merchant_id`, flashes a security warning, and redirects to `/admin` (or returns 403 JSON for API requests). Superadmins are exempt — they can legitimately switch brands via `BrandController::switchBrand`. |
| #239 | DNS verification bypass via domain update endpoint | CRITICAL | Removed `dns_verified` and `status` from the user-controllable fields in `DomainController::update()`. The endpoint now only modifies `type` and `redirect_url`. Existing `dns_verified` and `status` values are preserved in the DB because `updateScoped()` only writes the keys present in `$updateData` (verified via `BaseRepository::update` and `TenantScope::updateScoped`, both of which use `array_intersect_key` against `$fillable`). DNS verification status now ONLY changes via `DomainService::verify()` (gated by `DnsVerifier::verifyTxt()` real DNS lookup) or `Cron\DnsVerificationJob::run()` (also gated by `verifyTxt()`). Also removes the hidden `status` and `dns_verified` form fields from the `domains _manage-panel.twig` template since the server now ignores them. |
| #257 | Twig `env()` exposing DB passwords | CRITICAL | Removed the `env` `TwigFunction` registration from `getFunctions()` and deleted the `env()` method entirely. No template in the codebase currently uses `{{ env() }}` (verified via grep across `templates/` and `modules/`), so the removal is a pure security tightening with zero behavioral impact. If a future feature requires exposing specific safe configuration values to templates, it should be implemented as an explicit allow-list function backed by a hardcoded `ALLOWED_TEMPLATE_ENV_KEYS` constant — never a passthrough to `getenv()`. |
| #274 | TOTP secret leaked to third-party QR service | CRITICAL | Renders the QR code server-side via `chillerlan/php-qrcode` (already a composer dependency, `^5.0`), which produces an inline `data:image/svg+xml;base64,…` URI using the SVG output mode (no `ext-gd` required). The controller passes only the data URI (`qr_data_uri`) to the template — the raw `otpauth://` URI is never exposed to the template layer, eliminating the risk of a future template change accidentally rendering it. No network request is made; the TOTP secret never leaves the OwnPay server. The template gracefully falls back to displaying the manual-entry secret code if QR rendering fails (`caught \Throwable returns null`). |

## Workflow per issue

1. **Fix** the issue (one issue at a time)
2. **Run PHPStan level 9** check — 0 errors confirmed on the final state
3. **Commit** with `Signed-off-by: Fattain Naime <iamnaime@builderhall.com>` + `Co-authored-by: OwnPay Bot <bot@ownpay.org>` + issue ID in the body

## Verification

- **PHPStan**: `php vendor/bin/phpstan analyse --level=9 --no-progress` → `[OK] No errors`
- **Branch**: `fix/critical-audit-issues`, 9 commits ahead of `dev`
- **Audit trail**: every commit message documents the vulnerability, the fix, the security rationale, and references the issue ID

## Issues

Closes #121
Closes #173
Closes #174
Closes #198
Closes #237
Closes #238
Closes #239
Closes #257
Closes #274
