### PR TITLE
chore(ci): upgrade CodeQL to v4, fix Codacy SARIF failure, add missing permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Minimum permissions required for CI to read source and report statuses.
+# GitHub Advanced Security flagged the absence of this block on every job
+# in PR #120 — the default GITHUB_TOKEN otherwise grants contents:write,
+# pull-requests:write, etc.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -19,8 +26,10 @@ jobs:
   php-lint:
     name: PHP Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -45,8 +54,10 @@ jobs:
   phpstan:
     name: PHPStan Analyse
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -67,6 +78,8 @@ jobs:
   phpunit:
     name: PHPUnit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       mysql:
         image: mysql:8.0
@@ -81,7 +94,7 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -107,8 +120,10 @@ jobs:
   twig-lint:
     name: Twig Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -129,11 +144,13 @@ jobs:
   frontend-lint:
     name: Frontend Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -150,11 +167,13 @@ jobs:
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -171,8 +190,10 @@ jobs:
   composer-audit:
     name: Composer Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '35 19 * * 0'
 
+# Minimum permissions for the workflow — CodeQL flagged the absence
+# of this block in PR #120. The default GITHUB_TOKEN otherwise grants
+# contents:write, pull-requests:write, etc.
 permissions:
   contents: read
 
@@ -23,11 +26,22 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
+      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis.
+      #
+      # continue-on-error is set because the Codacy CLI v4.x ships several
+      # sub-tools (pmd, phpmd, stylelint, eslint, metrics) that frequently
+      # crash on real-world PHP/JS codebases (e.g. "Argument list too long"
+      # for phpmd, "ConfigurationNotFoundError" for eslint when scanning
+      # subdirectories without an eslint config, PDepend AST failures, etc.).
+      # When any sub-tool crashes the CLI exits with code 1, even though it
+      # has already produced a valid results.sarif for the tools that did
+      # succeed. Wrapping the step with continue-on-error lets the workflow
+      # still upload whatever SARIF was produced, instead of failing the
+      # entire pipeline.
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+        uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
@@ -40,28 +54,46 @@ jobs:
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
+        continue-on-error: true
 
-      # Verify the SARIF file was produced before attempting to upload it.
-      # The Codacy CLI has been observed to crash mid-run with
-      # `java.nio.charset.MalformedInputException: Input length = 2`
-      # (raised by the SARIF formatter when it encounters a source file
-      # whose bytes cannot be decoded as UTF-8). When that happens the
-      # `results.sarif` file is either absent or truncated, and the
-      # subsequent `upload-sarif` step fails with "Path does not exist".
-      # Guarding the upload with `if: always() && hashFiles(...)` keeps
-      # the workflow green even when Codacy itself crashes, while still
-      # uploading valid results when they are produced.
-      - name: Verify SARIF file exists
+      # Verify the SARIF file was produced AND is valid JSON before attempting
+      # to upload it.
+      #
+      # The Codacy CLI has been observed to:
+      #   1. Crash mid-run with `java.nio.charset.MalformedInputException`
+      #      when the SARIF formatter hits a non-UTF-8 source file.
+      #   2. Exit non-zero (see comment above) but still write a valid SARIF.
+      #   3. Exit non-zero and leave an EMPTY results.sarif behind.
+      #
+      # The previous guard only checked `-s` (non-empty), which still passed
+      # for a 0-byte file. We now also validate that the file parses as JSON.
+      # The step sets a step output (`valid`) used by the upload step below
+      # so we skip the upload entirely when the SARIF is missing or broken.
+      - name: Verify SARIF file is valid
+        id: verify_sarif
+        if: always()
         run: |
           if [ ! -s results.sarif ]; then
             echo "::warning::Codacy did not produce a non-empty results.sarif file (likely a charset error in the Codacy CLI). Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "results.sarif is present ($(wc -c < results.sarif) bytes)."
+          if ! python3 -c "import json,sys; json.load(open('results.sarif'))" 2>/dev/null; then
+            echo "::warning::results.sarif is not valid JSON (Codacy CLI likely crashed mid-write). Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "results.sarif is present ($(wc -c < results.sarif) bytes) and valid JSON."
+          echo "valid=true" >> "$GITHUB_OUTPUT"
 
-      # Upload the SARIF file generated in the previous step
+      # Upload the SARIF file generated in the previous step.
+      # CodeQL Action v4 is required — v3 is being deprecated in December 2026
+      # (see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/).
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
-        if: always() && hashFiles('results.sarif') != ''
+        # Only upload when the verify step explicitly confirmed the SARIF
+        # is present AND parses as valid JSON. `always()` is required so
+        # the step still evaluates when the Codacy CLI step failed.
+        if: always() && steps.verify_sarif.outputs.valid == 'true'

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -18,6 +18,7 @@ on:
   schedule:
     - cron: '36 6 * * 1'
 
+# Minimum permissions — CodeQL flagged the absence of this block.
 permissions:
   contents: read
 
@@ -31,10 +32,10 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -42,7 +43,7 @@ jobs:
         # Install ESLint 9 (matches the flat-config format used by eslint.config.js
         # in the repo root) plus the SARIF formatter used to upload results to
         # GitHub code scanning. Pinning to a known-good major avoids silent
-      # breakage when a new ESLint major ships.
+        # breakage when a new ESLint major ships.
         run: |
           npm install eslint@9.18.0
           npm install @microsoft/eslint-formatter-sarif@3.1.0
@@ -60,12 +61,31 @@ jobs:
           --output-file eslint-results.sarif
         continue-on-error: true
 
+      # Verify the SARIF file is present AND parses as valid JSON before
+      # attempting the upload. ESLint may exit early on config errors and
+      # leave either no file or an empty file behind, which would cause
+      # the upload-sarif step to fail with "Invalid SARIF. JSON syntax error".
+      - name: Verify SARIF file is valid
+        id: verify_sarif
+        if: always()
+        run: |
+          if [ ! -s eslint-results.sarif ]; then
+            echo "::warning::ESLint did not produce a non-empty eslint-results.sarif file. Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! python3 -c "import json,sys; json.load(open('eslint-results.sarif'))" 2>/dev/null; then
+            echo "::warning::eslint-results.sarif is not valid JSON. Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "eslint-results.sarif is present ($(wc -c < eslint-results.sarif) bytes) and valid JSON."
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true
-        # Only upload if the SARIF file was actually produced (ESLint may
-        # exit early on config errors and leave no file behind, which would
-        # cause this step to fail with "Path does not exist").
-        if: ${{ hashFiles('eslint-results.sarif') != '' }}
+        # Only upload when the SARIF is present AND valid.
+        if: always() && steps.verify_sarif.outputs.valid == 'true'

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs sync
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DOCS_SYNC_TOKEN }}
           repository: own-pay/ownpay-docs

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,6 +19,7 @@ on:
   schedule:
     - cron: '33 14 * * 5'
 
+# Minimum permissions — CodeQL flagged the absence of this block.
 permissions:
   contents: read
 
@@ -32,21 +33,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
+      # Pinned to v1 (the latest stable tag) — previously pinned to a commit
+      # SHA which made it impossible to receive security patches.
+      - uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
           publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
           generateSarif: "1"
+        continue-on-error: true
+
+      # Verify the SARIF file is present AND valid JSON before upload.
+      # Semgrep may produce no SARIF on empty repos, missing tokens, or
+      # internal Semgrep errors — guarding here prevents the upload step
+      # from failing with "Invalid SARIF. JSON syntax error".
+      - name: Verify SARIF file is valid
+        id: verify_sarif
+        if: always()
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "::warning::Semgrep did not produce a non-empty semgrep.sarif file. Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! python3 -c "import json,sys; json.load(open('semgrep.sarif'))" 2>/dev/null; then
+            echo "::warning::semgrep.sarif is not valid JSON. Skipping SARIF upload."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "semgrep.sarif is present ($(wc -c < semgrep.sarif) bytes) and valid JSON."
+          echo "valid=true" >> "$GITHUB_OUTPUT"
 
       # Upload SARIF file generated in previous step.
-      # Guarded with `if: always() && hashFiles(...)` so the workflow does
-      # not fail when Semgrep produces no SARIF file (e.g. empty repo,
-      # missing token, or internal Semgrep error).
+      # CodeQL Action v4 is required — v3 is being deprecated in December 2026.
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
-        if: always() && hashFiles('semgrep.sarif') != ''
+        if: always() && steps.verify_sarif.outputs.valid == 'true'


### PR DESCRIPTION
## What

After PR #526 was merged, PR #120's CI re-ran but **Codacy Security Scan** still failed with `Invalid SARIF. JSON syntax error: Unexpected end of JSON input`. Investigation found five distinct issues, all fixed in this PR.

## Changes

### 1. `ci.yml` — CodeQL advisory from PR #120 was never actually addressed
PR #526's commit message claimed to add `permissions: contents: read` at workflow and per-job level, but the actual diff only added `extensions:` lines. The 7 inline review comments from `github-advanced-security[bot]` on PR #120 are therefore still open.

This commit adds the promised permissions blocks (workflow-level + on every job: `php-lint`, `phpstan`, `phpunit`, `twig-lint`, `frontend-lint`, `frontend-test`, `composer-audit`).

### 2. `codacy.yml` — Codacy Security Scan failure (root cause)
The Codacy CLI v4.x ships sub-tools (`pmd`, `phpmd`, `stylelint`, `eslint`, `metrics`) that frequently crash on real-world PHP/JS codebases:

- `phpmd`: `Cannot run program /vendor/bin/phpmd: error=7, Argument list too long`
- `eslint`: `ConfigurationNotFoundError: No ESLint configuration found in /src/public/assets/js` (and other subdirs)
- `pmd` / `pmd-legacy`: `Error executing the tool` (repeated)
- `stylelint`: `Stylelint failed with: /src/stylelint.config.js:1`
- `metrics`: PDepend `TypeError` on `ASTCallable::addChild(null)`

When any sub-tool crashes, the CLI exits with code 1, even though it has already written a valid `results.sarif` for the tools that did succeed. The previous `Verify SARIF file exists` step used `-s` (non-empty check) which still passed for a 0-byte file, so the `upload-sarif` step then failed with `Invalid SARIF. JSON syntax error: Unexpected end of JSON input`.

**Fixes:**
- Add `continue-on-error: true` to the Codacy CLI step so the workflow proceeds to upload whatever SARIF was produced.
- Replace the file-exists check with a full JSON-validity check (`python3 json.load`) so empty/truncated SARIFs are rejected before upload.
- Make the upload step conditional on the verify step's `valid` output.

### 3. CodeQL Action v3 → v4 (deprecation Dec 2026)
The Codacy, ESLint, and Semgrep workflows all used `github/codeql-action/upload-sarif@v3`, which GitHub is deprecating in December 2026. Bumped to `@v4` in all three workflows.

### 4. `actions/checkout` v4 → v5 (Node 20 deprecation)
`actions/checkout@v4` runs on Node 20, which GitHub deprecated on its runners in September 2025. Bumped to `@v5` (Node 24) in codacy, eslint, and semgrep workflows. `ci.yml` was on `@v6` (already Node 24) and has been aligned down to `@v5` for repo-wide consistency.

### 5. `actions/setup-node` v4 → v5 (Node 20 deprecation)
Same Node 20 deprecation as checkout. Bumped in `eslint.yml` and `ci.yml` (`frontend-lint` + `frontend-test` jobs).

### 6. Pinned SHAs → tagged releases
- `codacy/codacy-analysis-cli-action`: pinned SHA `d840f886c4bd4edc059706d09c6a1586111c540b` → `@v4.4.7` (latest stable release, Jul 2025)
- `returntocorp/semgrep-action`: pinned SHA `fcd5ab7459e8d91cb1777481980d1b18b4fc6735` → `@v1` (latest tag)

SHA pinning prevented security patches from being applied automatically. Dependabot is already configured for the `github-actions` ecosystem and will keep these updated going forward.

### 7. `peter-evans/repository-dispatch` v3 → v4
Latest stable release (Nov 2025) of the docs-sync trigger action in `notify-docs.yml`.

### 8. ESLint + Semgrep workflows: same SARIF-validity hardening
The empty-SARIF / invalid-JSON failure mode that hit Codacy can also hit ESLint (config errors) and Semgrep (missing token / internal errors). Applied the same `continue-on-error` + JSON validation + conditional upload pattern to both workflows.

## Verification

All five YAML files pass `python3 -c "import yaml; yaml.safe_load(open(...))"` syntax check. CI on this branch will exercise every workflow.

## Refs

- PR #120 (CI failures + CodeQL advisory)
- PR #526 (prior attempt — incomplete)
