### PR TITLE
chore(ci): bound Codacy per-tool timeout to 180s

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -40,6 +40,15 @@ jobs:
       # succeed. Wrapping the step with continue-on-error lets the workflow
       # still upload whatever SARIF was produced, instead of failing the
       # entire pipeline.
+      #
+      # tool-timeout bounds each sub-tool to 3 minutes (180s). The Codacy
+      # action's default is 10 minutes per tool, which on a codebase the
+      # size of OwnPay (with ~6 sub-tools) yields a worst-case run of
+      # ~60 minutes. The previous run was observed hanging at 30+ minutes
+      # before being cancelled. 3 minutes per tool is plenty for any
+      # sub-tool that actually finishes; if a sub-tool needs more it is
+      # almost certainly stuck (PDepend AST walker on PHP 8.3 syntax,
+      # phpmd "Argument list too long", etc.) and should be killed.
       - name: Run Codacy Analysis CLI
         uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
@@ -54,6 +63,10 @@ jobs:
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
+          # Per-tool timeout in seconds. Default is 600 (10 min) which on
+          # OwnPay's codebase causes the workflow to hang for 30+ minutes
+          # when sub-tools get stuck on PHP 8.3 / complex AST patterns.
+          tool-timeout: 180
         continue-on-error: true
 
       # Verify the SARIF file was produced AND is valid JSON before attempting


### PR DESCRIPTION
## What

After PR #527 upgraded `codacy/codacy-analysis-cli-action` from a pinned SHA (CLI v4.0.0) to v4.4.7 (CLI v7.9.11+), the Codacy Security Scan workflow on PR #120 hung for **30+ minutes** before being manually cancelled.

## Root cause

The new CLI version runs additional sub-tools and uses the Codacy action's default per-tool timeout of **600 seconds (10 minutes)**, which yields a worst-case runtime of ~60 minutes on a codebase the size of OwnPay (with ~6 sub-tools: `pmd`, `phpmd`, `stylelint`, `eslint`, `metrics`, `pmd-legacy`).

## Fix

Set `tool-timeout: 180` to bound each sub-tool to 3 minutes. This is plenty for any sub-tool that actually finishes — if a sub-tool needs more time it is almost certainly stuck on a known-bad pattern:

- `PDepend` AST walker on PHP 8.3 syntax (`TypeError: Argument 1 passed to ASTCallable::addChild() must implement ASTNode, null given`)
- `phpmd` `Cannot run program /vendor/bin/phpmd: error=7, Argument list too long`
- `stylelint` config errors (`Stylelint failed with: /src/stylelint.config.js:1`)

The `continue-on-error: true` on the same step (added in PR #527) means sub-tool timeouts no longer fail the workflow — the verify + upload steps will still run on whatever SARIF was produced.

## Refs

- PR #527 — original CodeQL v4 + Codacy fix (this is the follow-up)
- PR #120 — the dev→main PR where Codacy was hanging
