### PR TITLE
fix(ci): use duration string for Codacy tool-timeout

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -63,10 +63,15 @@ jobs:
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
-          # Per-tool timeout in seconds. Default is 600 (10 min) which on
+          # Per-tool timeout. Default is 600 seconds (10 min) which on
           # OwnPay's codebase causes the workflow to hang for 30+ minutes
           # when sub-tools get stuck on PHP 8.3 / complex AST patterns.
-          tool-timeout: 180
+          #
+          # NOTE: Codacy CLI v7.9.x changed --tool-timeout to require a
+          # duration string (e.g. "3minutes", "180seconds") instead of a
+          # bare integer. The codacy-analysis-cli-action@v4.4.7 wrapper
+          # passes the value through verbatim, so we use "3minutes" here.
+          tool-timeout: 3minutes
         continue-on-error: true
 
       # Verify the SARIF file was produced AND is valid JSON before attempting


### PR DESCRIPTION
## What

Follow-up to PR #528. Codacy CLI v7.9.x (introduced via `codacy-analysis-cli-action@v4.4.7`) changed the `--tool-timeout` flag to require a duration string like `3minutes` or `180seconds` instead of a bare integer. The action wrapper passes the value through verbatim, so `180` was being rejected with:

```
Invalid duration 180 (e.g. 20minutes, 10seconds, ...)
```

This caused the Codacy CLI step to exit with code 1 immediately (in ~8 seconds) before any analysis was performed. The workflow still passed because of the `continue-on-error` + verify guards added in PR #527, but **no Codacy analysis was actually being uploaded to GitHub code scanning**.

## Fix

Switch `tool-timeout: 180` → `tool-timeout: 3minutes`. The CLI now parses the timeout correctly and actually runs the analysis. The 3-minute per-tool bound is still in effect, so the workflow cannot hang the way it did when the default 10-minute timeout was in use.

## Refs

- PR #527 — original CodeQL v4 + Codacy SARIF hardening
- PR #528 — introduced `tool-timeout: 180` (broken format)
- PR #120 — the dev→main PR where Codacy was failing
