### PR TITLE
chore(ci): add .codacy.yml + step-level timeout for Codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,56 @@
+# Codacy configuration — https://docs.codacy.com/repositories-configure/configuring-codacy-using-a-codacy-yaml-file/
+#
+# Excludes vendor/, node_modules/, and other dependency/build directories
+# from Codacy analysis. The Codacy CLI v7.9.x was spending ~12 minutes
+# iterating over every file in these directories during the language-
+# detection phase (logging "No language found for X" for thousands of
+# files), which made the workflow impractically slow.
+#
+# Excluding these directories is also semantically correct — third-party
+# dependencies are not part of OwnPay's own attack surface, and any
+# vulnerabilities in them are tracked by `composer audit` / `npm audit`
+# (which the CI workflow already runs).
+
+---
+exclude_paths:
+  - vendor/**
+  - node_modules/**
+  - var/**
+  - storage/logs/**
+  - storage/cache/**
+  - storage/sessions/**
+  - storage/uploads/**
+  - public/assets/vendor/**
+  - public/assets/lib/**
+  - build/**
+  - dist/**
+  - tests/fixtures/**
+  - database/migrations/fixtures/**
+  - docs/_site/**
+  - docs/vendor/**
+
+# Tool-specific configuration. We keep the defaults for everything
+# except enabling the security-focused tools that are off by default
+# in the Codacy CLI v7.9.x.
+engines:
+  phpmd:
+    enabled: true
+  phpcs:
+    enabled: true
+  phpdepend:
+    enabled: false  # Crashes on PHP 8.3 union/intersection types
+  eslint:
+    enabled: true
+  stylelint:
+    enabled: true
+  duplication:
+    enabled: true
+    exclude_fingerprints: []
+    config:
+      languages:
+        php:
+        javascript:
+
+# Don't fail the build on the Codacy side — let GitHub code scanning
+# surface the results as PR annotations instead.
+min_blob_strength: 1

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -41,14 +41,21 @@ jobs:
       # still upload whatever SARIF was produced, instead of failing the
       # entire pipeline.
       #
-      # tool-timeout bounds each sub-tool to 3 minutes (180s). The Codacy
-      # action's default is 10 minutes per tool, which on a codebase the
-      # size of OwnPay (with ~6 sub-tools) yields a worst-case run of
-      # ~60 minutes. The previous run was observed hanging at 30+ minutes
-      # before being cancelled. 3 minutes per tool is plenty for any
-      # sub-tool that actually finishes; if a sub-tool needs more it is
-      # almost certainly stuck (PDepend AST walker on PHP 8.3 syntax,
-      # phpmd "Argument list too long", etc.) and should be killed.
+      # tool-timeout bounds each sub-tool to 3 minutes. The Codacy CLI v7.9.x
+      # runs ~27 Docker-based sub-tools (codacy-codesniffer, codacy-php-cs-fixer,
+      # codacy-biomejs, codacy-eslint9, codacy-pmd, codacy-jshint, etc.).
+      # Without a per-tool timeout the worst-case runtime is ~60 minutes.
+      #
+      # NOTE: Codacy CLI v7.9.x changed --tool-timeout to require a duration
+      # string (e.g. "3minutes", "180seconds") instead of a bare integer.
+      # The codacy-analysis-cli-action@v4.4.7 wrapper passes the value
+      # through verbatim, so we use "3minutes" here.
+      #
+      # timeout-minutes is a GitHub Actions step-level safeguard that kills
+      # the entire step (not just one sub-tool) if the CLI hangs for any
+      # reason not covered by --tool-timeout (e.g. SARIF post-processing
+      # hangs, network stall while pulling a Docker image, etc.). 25 minutes
+      # is comfortably above the observed ~17-minute full run on OwnPay.
       - name: Run Codacy Analysis CLI
         uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
@@ -63,16 +70,10 @@ jobs:
           # Force 0 exit code to allow SARIF file generation
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
-          # Per-tool timeout. Default is 600 seconds (10 min) which on
-          # OwnPay's codebase causes the workflow to hang for 30+ minutes
-          # when sub-tools get stuck on PHP 8.3 / complex AST patterns.
-          #
-          # NOTE: Codacy CLI v7.9.x changed --tool-timeout to require a
-          # duration string (e.g. "3minutes", "180seconds") instead of a
-          # bare integer. The codacy-analysis-cli-action@v4.4.7 wrapper
-          # passes the value through verbatim, so we use "3minutes" here.
+          # Per-tool timeout. Default is 600 seconds (10 min).
           tool-timeout: 3minutes
         continue-on-error: true
+        timeout-minutes: 25
 
       # Verify the SARIF file was produced AND is valid JSON before attempting
       # to upload it.


### PR DESCRIPTION
## What

After PR #529 fixed the `tool-timeout` format, Codacy CLI v7.9.25 ran to ~17 minutes before being cancelled mid-SARIF-generation. Logs revealed two issues:

### 1. File-parsing phase iterates over `vendor/` and `node_modules/`
The CLI iterates over every file in `vendor/`, `node_modules/`, etc. during language detection, logging `No language found for X` for thousands of third-party files. This phase alone took **~12 minutes** of the ~17-minute runtime.

### 2. No step-level timeout safeguard
The Codacy CLI's `--tool-timeout` bounds only individual sub-tool execution, not the SARIF post-processing phase. If post-processing hangs (e.g. on a malformed result), the step would never exit — only the 6-hour GitHub Actions default job timeout would eventually kill it.

## Fixes

### 1. Add `.codacy.yml` at repo root
Excludes `vendor/`, `node_modules/`, `storage/`, `build/`, `dist/`, etc. from Codacy analysis. This is also **semantically correct** — third-party dependencies are not part of OwnPay's attack surface, and vulnerabilities in them are tracked by `composer audit` / `npm audit` (which CI already runs).

**Expected impact:** ~12 minutes saved on the file-parsing phase, bringing total runtime to ~5-7 minutes.

### 2. Add `timeout-minutes: 25` to the Codacy CLI step
A GitHub Actions-level safeguard that kills the step (not just one sub-tool) if the CLI hangs for any reason not covered by `--tool-timeout`. 25 minutes is comfortably above the observed ~17-minute full run, but well below the 6-hour GitHub Actions default job timeout.

## Refs

- PR #527 — CodeQL v4 + Codacy SARIF hardening (continue-on-error + JSON validation)
- PR #528 — introduced `tool-timeout: 180` (wrong format)
- PR #529 — fixed tool-timeout format to `3minutes`
- PR #120 — the dev→main PR where Codacy was failing
