### PR TITLE
fix(tests): phpunit test fixes for brand scoping, datetime normalization, translation recovery, update signing

### DIFF
--- a/database/migrations/005_add_customer_status_and_address.sql
+++ b/database/migrations/005_add_customer_status_and_address.sql
@@ -1,0 +1,10 @@
+-- Migration: Add status and address_enc columns to op_customers
+-- Adds soft-delete (status) and address field (address_enc) to customers
+-- Required by audit fix CUS-4 (soft-delete row exclusion) and audit fix CUS-3 (address PII)
+
+ALTER TABLE `op_customers`
+    ADD COLUMN `address_enc` VARBINARY(1024) DEFAULT NULL AFTER `phone_hash`,
+    ADD COLUMN `status` ENUM('active','deleted') NOT NULL DEFAULT 'active' AFTER `address_enc`;
+
+-- Index for status filter
+CREATE INDEX `idx_merchant_status` ON `op_customers` (`merchant_id`, `status`);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -234,7 +234,9 @@ CREATE TABLE `op_customers` (
   `email_hash` VARCHAR(64) NOT NULL,
   `phone_enc` VARBINARY(512) DEFAULT NULL,
   `phone_hash` VARCHAR(64) DEFAULT NULL,
+  `address_enc` VARBINARY(1024) DEFAULT NULL,
   `metadata` JSON DEFAULT NULL,
+  `status` ENUM('active','deleted') NOT NULL DEFAULT 'active',
   `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
@@ -242,6 +244,7 @@ CREATE TABLE `op_customers` (
   UNIQUE KEY `uk_merchant_email` (`merchant_id`, `email_hash`),
   KEY `idx_merchant` (`merchant_id`),
   KEY `idx_merchant_phone_hash` (`merchant_id`, `phone_hash`),
+  KEY `idx_merchant_status` (`merchant_id`, `status`),
   CONSTRAINT `fk_cust_merchant` FOREIGN KEY (`merchant_id`) REFERENCES `op_merchants` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/database/seeds/roles.sql
+++ b/database/seeds/roles.sql
@@ -40,6 +40,7 @@ INSERT INTO `op_permissions` (`slug`, `name`, `group_name`) VALUES
 ('staff.delete', 'Delete Staff', 'staff'),
 ('brands.view', 'View Brands', 'brands'),
 ('brands.manage', 'Manage Brands', 'brands'),
+('brands.access_all', 'Access All Brands view', 'brands'),
 -- Merchants
 ('merchants.view', 'View Merchants', 'merchants'),
 ('merchants.create', 'Create Merchants', 'merchants'),

--- a/src/Controller/Admin/ApiKeyController.php
+++ b/src/Controller/Admin/ApiKeyController.php
@@ -156,8 +156,8 @@ final class ApiKeyController
             $this->audit->log('api_key.revoked', 'api_keys', $id, null, ['merchant_id' => $mid]);
         }
         $referer = $req->header('Referer');
-        $redirectUrl = str_contains($referer, '/admin/settings') 
-            ? '/admin/settings#tab-api' 
+        $redirectUrl = str_contains($referer, '/admin/settings')
+            ? '/admin/settings#tab-api'
             : '/admin/developer';
         return Response::redirect($redirectUrl);
     }

--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -458,7 +458,7 @@ final class TransactionRepository extends BaseRepository
             "SELECT t.*, m.name as merchant_name, m.id as merchant_id
              FROM {$this->table} t
              JOIN op_merchants m ON m.id = t.merchant_id
-             WHERE t.trx_id = :ref AND t.status IN ('pending','created')
+             WHERE t.trx_id = :ref AND t.status IN ('pending','created','processing')
              LIMIT 1",
             ['ref' => $trxId]
         );

--- a/src/Service/Brand/BrandContext.php
+++ b/src/Service/Brand/BrandContext.php
@@ -215,7 +215,17 @@ final class BrandContext
         if (session_status() === PHP_SESSION_ACTIVE) {
             $mode = $_SESSION['brand_view_mode'] ?? 'single';
         }
-        return ($this->getActiveBrandId() === null) || ($mode === 'global');
+        // activeBrandId === 0 is the canonical "All Brands" marker (set by
+        // resolveFromRequest() when merchant_id=0 is passed via the request
+        // attribute, and by tests that explicitly assign
+        // $_SESSION['active_brand_id'] = 0). Treating 0 as global here keeps
+        // isGlobalView() consistent with getWriteMerchantId() (which calls
+        // isGlobalView() first, then falls back to getPlatformId() when the
+        // brand id is 0). Without this, a request with merchant_id=0 would
+        // be treated as brand-scoped, causing platform-owned resources (API
+        // keys, etc.) to be unreachable from the All Brands view.
+        $activeBrandId = $this->getActiveBrandId();
+        return ($activeBrandId === null) || ($activeBrandId === 0) || ($mode === 'global');
     }
 
     /**

--- a/src/Service/Customer/ApiKeyService.php
+++ b/src/Service/Customer/ApiKeyService.php
@@ -87,20 +87,46 @@ final class ApiKeyService
         $maxTimestamp = time() + self::MAX_KEY_LIFETIME_SECONDS;
 
         if ($expiresAt === null || $expiresAt === '') {
-            return date('c', $maxTimestamp);
+            return $this->normalizeDatetime($maxTimestamp);
         }
 
         $parsed = strtotime($expiresAt);
         if ($parsed === false) {
             // Unparseable input — fail safe to the default max lifetime.
-            return date('c', $maxTimestamp);
+            return $this->normalizeDatetime($maxTimestamp);
         }
 
         if ($parsed > $maxTimestamp) {
-            return date('c', $maxTimestamp);
+            return $this->normalizeDatetime($maxTimestamp);
         }
 
-        return $expiresAt;
+        return $this->normalizeDatetime($parsed);
+    }
+
+    /**
+     * Normalizes a Unix timestamp into a MariaDB/MySQL-friendly datetime string.
+     *
+     * PHP's `date('c', $ts)` produces an ISO-8601 string like
+     * "2027-08-13T23:21:08+00:00". While that format is valid ISO-8601, the
+     * `DATETIME[(6)]` column type used throughout OwnPay rejects the `T`
+     * separator and the timezone offset on MariaDB 11.x with the default
+     * `STRICT_TRANS_TABLES` sql_mode, raising:
+     *
+     *   SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime
+     *   value: '2027-08-13T23:21:08+00:00' for column ... `expires_at`
+     *
+     * To keep the storage layer robust regardless of the host's sql_mode, we
+     * always emit the canonical `Y-m-d H:i:s` representation. The timezone
+     * offset is intentionally dropped because DATETIME columns store the
+     * literal value verbatim (they are not timezone-aware); the application
+     * layer treats all stored timestamps as UTC.
+     *
+     * @param int $timestamp Unix timestamp (assumed UTC).
+     * @return non-empty-string Formatted as "Y-m-d H:i:s" in UTC.
+     */
+    private function normalizeDatetime(int $timestamp): string
+    {
+        return gmdate('Y-m-d H:i:s', $timestamp);
     }
 
     /**

--- a/src/Service/System/TranslationService.php
+++ b/src/Service/System/TranslationService.php
@@ -470,10 +470,21 @@ final class TranslationService
 
         if (!file_exists($filePath)) {
             $dbTranslations = $this->loadTranslationsFromDb($code);
-            if (!empty($dbTranslations)) {
+            // Recovery path: when the on-disk JSON is missing but the language
+            // exists in the database (even with an empty translations payload —
+            // common right after createLanguage() copies '{}' for a brand-new
+            // locale), we must re-materialise the file. Otherwise the next
+            // setLocale()+trans() cycle finds the file still missing and the
+            // "automatic file recovery" contract documented by
+            // LanguageSystemTest::testAutomaticLanguageFileRecovery breaks.
+            // We therefore key the write off language existence in the DB
+            // (loadTranslationsFromDb returns [] for both "no row" and
+            // "row with {} payload"), and distinguish the two cases here by
+            // asking exists() which goes through the same DB.
+            if (!empty($dbTranslations) || $this->exists($code)) {
                 $json = json_encode($dbTranslations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
                 if ($json !== false) {
-                    @file_put_contents($filePath, $json, LOCK_EX);
+                    @file_put_contents($filePath, $json === '' ? '{}' : $json, LOCK_EX);
                     @chmod($filePath, 0664);
                 }
                 return array_merge($base, $dbTranslations);

--- a/src/Update/UpdateService.php
+++ b/src/Update/UpdateService.php
@@ -27,8 +27,15 @@ class UpdateService
 {
     /**
      * Hardcoded RSA Public Key PEM used to verify cryptographically signed updates.
+     *
+     * Exposed as a protected static property (instead of a private const) so
+     * the test harness can substitute a test-only key pair without needing
+     * the production private key — see TestableUpdateService in
+     * tests/Unit/UpdateServiceTest.php.
+     *
+     * @var string
      */
-    private const UPDATE_PUBLIC_KEY = <<<EOT
+    protected static string $updatePublicKey = <<<EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzBVsd2Yd/xqMD00Dts/e
 OuSIjjYab3fRqEtRaPf9cAl0iFRR+o7RGloz6dh6M2trswiKx2s2mN4+JPL604Z/
@@ -358,7 +365,7 @@ EOT;
                 @unlink($packagePath);
                 throw new \RuntimeException("Failed to read downloaded package content.");
             }
-            $pubKeyResource = openssl_pkey_get_public(self::UPDATE_PUBLIC_KEY);
+            $pubKeyResource = openssl_pkey_get_public(self::$updatePublicKey);
             if ($pubKeyResource === false) {
                 @unlink($packagePath);
                 throw new \RuntimeException("Failed to load embedded public key for verification.");

--- a/tests/Integration/ApiKeyApiSecurityTest.php
+++ b/tests/Integration/ApiKeyApiSecurityTest.php
@@ -289,9 +289,22 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
     {
         $adminController = $this->container->get(\OwnPay\Controller\Admin\ApiKeyController::class);
 
+        // Seed a platform-owned key so the revoke has a real row to act on.
+        // Without this, revoke() returns 0 and the audit-fix error path
+        // ("API key not found or already revoked") fires, which the
+        // original test (written before the audit fix) did not expect.
+        $platformId = $this->db->fetchOne("SELECT id FROM op_merchants WHERE is_platform = 1 ORDER BY id ASC LIMIT 1")['id'] ?? null;
+        $this->assertNotNull($platformId, 'Platform merchant must exist');
+        $platformId = (int) $platformId;
+
+        $keyInfo = $this->apiKeyService->generate($platformId, 'Platform Revoke Test', ['read', 'write']);
+        $keyRow = $this->db->fetchOne("SELECT id FROM op_api_keys WHERE key_prefix = :p", ['p' => $keyInfo['prefix']]);
+        $this->assertIsArray($keyRow, 'Platform key must be persisted');
+        $keyId = (int) $keyRow['id'];
+
         $req = new Request([], []);
         $req->setAttribute('merchant_id', 0);
-        $req->setRouteParams(['id' => '123']);
+        $req->setRouteParams(['id' => (string) $keyId]);
 
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
@@ -301,5 +314,12 @@ final class ApiKeyApiSecurityTest extends IntegrationTestCase
 
         $this->assertSame(302, $res->getStatusCode());
         $this->assertNull($_SESSION['flash_error'] ?? null, 'No "select a brand" error in All Brands view');
+
+        // Verify the platform-owned key was actually revoked.
+        $revokedRow = $this->db->fetchOne("SELECT status FROM op_api_keys WHERE id = :id", ['id' => $keyId]);
+        $this->assertSame('revoked', $revokedRow['status'] ?? null, 'Platform key must be revoked in All Brands view');
+
+        // Cleanup
+        $this->db->execute("DELETE FROM op_api_keys WHERE id = :id", ['id' => $keyId]);
     }
 }

--- a/tests/Integration/CheckoutBackNavigationTest.php
+++ b/tests/Integration/CheckoutBackNavigationTest.php
@@ -73,9 +73,14 @@ final class CheckoutBackNavigationTest extends IntegrationTestCase
 
     private function insertTransaction(string $trxId, string $uuid, string $status, string $gateway = 'bkash-api', ?int $intentId = null): int
     {
+        // The 10-minute cooldown inside reactivateForRetry() (issue #338, PAY-10)
+        // means a freshly inserted `processing` row has updated_at = NOW() and is
+        // therefore NOT eligible for revert, which would make
+        // testProcessingTransactionShowsCheckoutPageNotStatus always fail.
+        // Back-date updated_at by 15 minutes so the revert path is exercised.
         $this->db->execute(
-            "INSERT INTO op_transactions (merchant_id, uuid, trx_id, payment_intent_id, gateway_slug, amount, net_amount, currency, method, status)
-             VALUES (:mid, :uuid, :trx, :pi, :gw, '100.00', '100.00', 'BDT', 'api', :status)",
+            "INSERT INTO op_transactions (merchant_id, uuid, trx_id, payment_intent_id, gateway_slug, amount, net_amount, currency, method, status, updated_at)
+             VALUES (:mid, :uuid, :trx, :pi, :gw, '100.00', '100.00', 'BDT', 'api', :status, DATE_SUB(NOW(6), INTERVAL 15 MINUTE))",
             ['mid' => $this->merchantId, 'uuid' => $uuid, 'trx' => $trxId, 'pi' => $intentId, 'gw' => $gateway, 'status' => $status]
         );
         $row = $this->db->fetchOne("SELECT id FROM op_transactions WHERE trx_id = :t", ['t' => $trxId]);
@@ -84,9 +89,12 @@ final class CheckoutBackNavigationTest extends IntegrationTestCase
 
     private function insertIntent(string $token, string $uuid, string $status): int
     {
+        // Back-date updated_at by 15 minutes so the cooldown predicate
+        // `updated_at < NOW() - INTERVAL 10 MINUTE` inside
+        // PaymentIntentRepository::reactivateForRetry() actually matches.
         $this->db->execute(
-            "INSERT INTO op_payment_intents (merchant_id, uuid, token, amount, currency, status, expires_at)
-             VALUES (:mid, :uuid, :token, '100.00', 'BDT', :status, DATE_ADD(NOW(6), INTERVAL 1 DAY))",
+            "INSERT INTO op_payment_intents (merchant_id, uuid, token, amount, currency, status, expires_at, updated_at)
+             VALUES (:mid, :uuid, :token, '100.00', 'BDT', :status, DATE_ADD(NOW(6), INTERVAL 1 DAY), DATE_SUB(NOW(6), INTERVAL 15 MINUTE))",
             ['mid' => $this->merchantId, 'uuid' => $uuid, 'token' => $token, 'status' => $status]
         );
         $row = $this->db->fetchOne("SELECT id FROM op_payment_intents WHERE token = :t", ['t' => $token]);

--- a/tests/Integration/CheckoutReactivateForRetryTest.php
+++ b/tests/Integration/CheckoutReactivateForRetryTest.php
@@ -54,9 +54,14 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
 
     private function insertTransaction(string $trxId, string $status, string $gateway = 'bkash-api', ?int $intentId = null): int
     {
+        // The cooldown inside reactivateForRetry() is `updated_at < NOW() - INTERVAL 10 MINUTE`
+        // (issue #338, PAY-10). A freshly inserted row has updated_at = NOW() by default,
+        // which would never satisfy that predicate and the test would always see `false`.
+        // We therefore back-date the row's updated_at by 15 minutes so the revert path
+        // is actually exercised.
         $this->db->execute(
-            "INSERT INTO op_transactions (merchant_id, uuid, trx_id, payment_intent_id, gateway_slug, amount, net_amount, currency, status, method)
-             VALUES (:mid, UUID(), :trx, :pi, :gw, 100.00, 100.00, 'BDT', :status, 'api')",
+            "INSERT INTO op_transactions (merchant_id, uuid, trx_id, payment_intent_id, gateway_slug, amount, net_amount, currency, status, method, updated_at)
+             VALUES (:mid, UUID(), :trx, :pi, :gw, 100.00, 100.00, 'BDT', :status, 'api', DATE_SUB(NOW(), INTERVAL 15 MINUTE))",
             ['mid' => $this->merchantId, 'trx' => $trxId, 'pi' => $intentId, 'gw' => $gateway, 'status' => $status]
         );
         $row = $this->db->fetchOne("SELECT id FROM op_transactions WHERE trx_id = :t", ['t' => $trxId]);
@@ -66,9 +71,11 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
 
     private function insertIntent(string $token, string $status): int
     {
+        // Same cooldown rationale as insertTransaction(): back-date updated_at so
+        // the revert path inside PaymentIntentRepository::reactivateForRetry() fires.
         $this->db->execute(
-            "INSERT INTO op_payment_intents (merchant_id, uuid, token, amount, currency, status, expires_at)
-             VALUES (:mid, UUID(), :token, 100.00, 'BDT', :status, DATE_ADD(NOW(), INTERVAL 1 DAY))",
+            "INSERT INTO op_payment_intents (merchant_id, uuid, token, amount, currency, status, expires_at, updated_at)
+             VALUES (:mid, UUID(), :token, 100.00, 'BDT', :status, DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL 15 MINUTE))",
             ['mid' => $this->merchantId, 'token' => $token, 'status' => $status]
         );
         $row = $this->db->fetchOne("SELECT id FROM op_payment_intents WHERE token = :t", ['t' => $token]);
@@ -80,7 +87,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
     {
         $this->insertTransaction('zzretry-txn-1', 'processing');
 
-        $reverted = $this->txnRepo->reactivateForRetry('zzretry-txn-1');
+        $reverted = $this->txnRepo->reactivateForRetry('zzretry-txn-1', $this->merchantId);
 
         $this->assertTrue($reverted);
         $row = $this->db->fetchOne("SELECT status FROM op_transactions WHERE trx_id = :t", ['t' => 'zzretry-txn-1']);
@@ -92,7 +99,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
     {
         $this->insertTransaction('zzretry-txn-2', $status);
 
-        $reverted = $this->txnRepo->reactivateForRetry('zzretry-txn-2');
+        $reverted = $this->txnRepo->reactivateForRetry('zzretry-txn-2', $this->merchantId);
 
         $this->assertFalse($reverted, "Must not revert a '{$status}' transaction");
         $row = $this->db->fetchOne("SELECT status FROM op_transactions WHERE trx_id = :t", ['t' => 'zzretry-txn-2']);
@@ -111,7 +118,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
     {
         $this->insertIntent('zzretry-intent-1', 'processing');
 
-        $reverted = $this->intentRepo->reactivateForRetry('zzretry-intent-1');
+        $reverted = $this->intentRepo->reactivateForRetry('zzretry-intent-1', $this->merchantId);
 
         $this->assertTrue($reverted);
         $row = $this->db->fetchOne("SELECT status FROM op_payment_intents WHERE token = :t", ['t' => 'zzretry-intent-1']);
@@ -123,7 +130,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
     {
         $this->insertIntent('zzretry-intent-2', $status);
 
-        $reverted = $this->intentRepo->reactivateForRetry('zzretry-intent-2');
+        $reverted = $this->intentRepo->reactivateForRetry('zzretry-intent-2', $this->merchantId);
 
         $this->assertFalse($reverted, "Must not revert a '{$status}' intent");
         $row = $this->db->fetchOne("SELECT status FROM op_payment_intents WHERE token = :t", ['t' => 'zzretry-intent-2']);
@@ -140,7 +147,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
         $intentId = $this->insertIntent('zzretry-intent-3', 'processing');
         $this->insertTransaction('zzretry-txn-3', 'processing', 'bkash-api', $intentId);
 
-        $reverted = $this->txnRepo->reactivateForRetryByIntentId($intentId);
+        $reverted = $this->txnRepo->reactivateForRetryByIntentId($intentId, $this->merchantId);
 
         $this->assertTrue($reverted);
         $row = $this->db->fetchOne("SELECT status FROM op_transactions WHERE trx_id = :t", ['t' => 'zzretry-txn-3']);
@@ -152,7 +159,7 @@ final class CheckoutReactivateForRetryTest extends IntegrationTestCase
         $intentId = $this->insertIntent('zzretry-intent-4', 'completed');
         $this->insertTransaction('zzretry-txn-4', 'completed', 'bkash-api', $intentId);
 
-        $reverted = $this->txnRepo->reactivateForRetryByIntentId($intentId);
+        $reverted = $this->txnRepo->reactivateForRetryByIntentId($intentId, $this->merchantId);
 
         $this->assertFalse($reverted);
         $row = $this->db->fetchOne("SELECT status FROM op_transactions WHERE trx_id = :t", ['t' => 'zzretry-txn-4']);

--- a/tests/Integration/DomainControllerAjaxResponseTest.php
+++ b/tests/Integration/DomainControllerAjaxResponseTest.php
@@ -140,8 +140,13 @@ final class DomainControllerAjaxResponseTest extends IntegrationTestCase
     {
         $this->activateBrand();
 
+        // The redirect_url must be same-origin with the seeded domain
+        // ('zz-ajax-test-99991.example.com') — DOM-2 audit fix tightened
+        // validateRedirectUrl() to reject any external host, so the original
+        // 'https://example.com/x' would now fail validation and the response
+        // would be success=false instead of the expected fresh domain state.
         $req = new Request([], [
-            'type' => 'api', 'redirect_url' => 'https://example.com/x',
+            'type' => 'api', 'redirect_url' => 'https://zz-ajax-test-' . $this->merchantId . '.example.com/x',
             'status' => 'pending', 'dns_verified' => '0', 'is_primary' => '0',
         ], [
             'REQUEST_METHOD' => 'POST',
@@ -156,7 +161,7 @@ final class DomainControllerAjaxResponseTest extends IntegrationTestCase
         $this->assertIsArray($body);
         $this->assertTrue($body['success']);
         $this->assertSame('api', $body['domain']['type']);
-        $this->assertSame('https://example.com/x', $body['domain']['redirect_url']);
+        $this->assertSame('https://zz-ajax-test-' . $this->merchantId . '.example.com/x', $body['domain']['redirect_url']);
         $this->assertSame('Pending DNS', $body['domain']['status_pill']['label']);
     }
 }

--- a/tests/Integration/InstallerLockTest.php
+++ b/tests/Integration/InstallerLockTest.php
@@ -148,7 +148,7 @@ final class InstallerLockTest extends IntegrationTestCase
             'name'     => 'Evil Admin',
             'email'    => 'evil@example.com',
             'username' => 'evil',
-            'password' => 'password123',
+            'password' => 'Password123!',
         ]));
 
         $this->assertSame(403, $response->getStatusCode());
@@ -188,7 +188,7 @@ final class InstallerLockTest extends IntegrationTestCase
                 'name'     => 'Rebuild Admin',
                 'email'    => 'rebuild@example.com',
                 'username' => 'rebuild',
-                'password' => 'password123',
+                'password' => 'Password123!',
             ],
             ['HTTP_X_INSTALL_FORCE_KEY' => 'force-key-0123456789abcdef']
         ));
@@ -209,7 +209,7 @@ final class InstallerLockTest extends IntegrationTestCase
                 'name'     => 'Evil Admin',
                 'email'    => 'evil2@example.com',
                 'username' => 'evil2',
-                'password' => 'password123',
+                'password' => 'Password123!',
             ],
             ['HTTP_X_INSTALL_FORCE_KEY' => 'short']
         ));
@@ -226,7 +226,7 @@ final class InstallerLockTest extends IntegrationTestCase
             'name'     => 'First Admin',
             'email'    => 'first@example.com',
             'username' => 'first',
-            'password' => 'password123',
+            'password' => 'Password123!',
         ]));
 
         $this->assertSame(400, $response->getStatusCode());

--- a/tests/Integration/OnboardingBrandStepTest.php
+++ b/tests/Integration/OnboardingBrandStepTest.php
@@ -59,7 +59,37 @@ final class OnboardingBrandStepTest extends IntegrationTestCase
     private function cleanup(): void
     {
         $this->db->execute("DELETE FROM op_merchants WHERE slug LIKE 'zzwizardbrand%' OR slug LIKE 'zz-wizardbrand%' OR slug LIKE 'zz-wizard-brand%'");
+        // Re-seed the canonical test merchants that other suites assume exist
+        // (id=1 "Test Merchant", id=2 "Test Merchant 2", id=500085 platform row).
+        // The two `test*` and `testConfigures…` methods below deliberately wipe
+        // every row in op_merchants to exercise the "zero brands" branch, so
+        // without this safety-net they would corrupt the database for every
+        // subsequent integration test (PasswordResetServiceTest,
+        // PaymentLinkAdminFixesTest, etc. all fail with FK 1452 otherwise).
+        $this->ensureSeedMerchantsExist();
         unset($_SESSION['active_brand_id'], $_SESSION['auth_merchant_id']);
+    }
+
+    /**
+     * Idempotently re-inserts the canonical seed merchants wiped by the
+     * "DELETE FROM op_merchants" inside the test bodies of this class.
+     *
+     * Wrapped in INSERT IGNORE so it is a no-op when the rows already exist.
+     */
+    private function ensureSeedMerchantsExist(): void
+    {
+        $this->db->execute(
+            "INSERT IGNORE INTO op_merchants (id, uuid, name, slug, email, status, settings)
+             VALUES (1, 'merchant-uuid-1', 'Test Merchant', 'test-merchant-1', 'test1@example.com', 'active', '{}')"
+        );
+        $this->db->execute(
+            "INSERT IGNORE INTO op_merchants (id, uuid, name, slug, email, status, settings)
+             VALUES (2, 'merchant-uuid-2', 'Test Merchant 2', 'test-merchant-2', 'test2@example.com', 'active', '{}')"
+        );
+        $this->db->execute(
+            "INSERT IGNORE INTO op_merchants (id, uuid, name, slug, email, status, is_platform, settings)
+             VALUES (500085, '00000000-0000-4000-8000-0000000000aa', 'All Brands (Platform)', '__platform__', 'platform@ownpay.local', 'active', 1, NULL)"
+        );
     }
 
     private function countBrands(): int

--- a/tests/Integration/PaymentLinkAdminFixesTest.php
+++ b/tests/Integration/PaymentLinkAdminFixesTest.php
@@ -72,7 +72,28 @@ final class PaymentLinkAdminFixesTest extends IntegrationTestCase
     private function cleanup(): void
     {
         $this->db->execute("DELETE FROM op_payment_links WHERE slug LIKE 'zzplink-%'");
+        // Re-seed the canonical test merchants so the foreign-key constraint
+        // `fk_pl_merchant` is satisfied even when earlier suites
+        // (OnboardingBrandStepTest) wiped op_merchants to exercise the
+        // "zero brands" branch of the onboarding wizard.
+        $this->ensureSeedMerchantsExist();
         unset($_SESSION['active_brand_id'], $_SESSION['brand_view_mode']);
+    }
+
+    /**
+     * Idempotently re-inserts the canonical seed merchants (id 1 and 2)
+     * assumed by $merchantId / $otherMerchantId above.
+     */
+    private function ensureSeedMerchantsExist(): void
+    {
+        $this->db->execute(
+            "INSERT IGNORE INTO op_merchants (id, uuid, name, slug, email, status, settings)
+             VALUES (1, 'merchant-uuid-1', 'Test Merchant', 'test-merchant-1', 'test1@example.com', 'active', '{}')"
+        );
+        $this->db->execute(
+            "INSERT IGNORE INTO op_merchants (id, uuid, name, slug, email, status, settings)
+             VALUES (2, 'merchant-uuid-2', 'Test Merchant 2', 'test-merchant-2', 'test2@example.com', 'active', '{}')"
+        );
     }
 
     private function insertLink(int $merchantId, string $slug): int

--- a/tests/Integration/RefundReconciliationJobTest.php
+++ b/tests/Integration/RefundReconciliationJobTest.php
@@ -77,18 +77,21 @@ final class RefundReconciliationJobTest extends IntegrationTestCase
         $this->insertRefund(8003, 'completed', "DATE_SUB(NOW(), INTERVAL 48 HOUR)");
 
         $fired = [];
-        $this->events->addAction('payment.refund.reconciliation_failed', function (...$args) use (&$fired): void {
+        $this->events->addAction('payment.refund.requires_verification', function (...$args) use (&$fired): void {
             $fired[] = $args[0] ?? null;
         });
 
         $result = $this->job->run();
 
-        $this->assertSame(1, $result['failed']);
+        // Audit fix CRON-7: the 'failed' key was renamed to 'requires_verification'
+        // and stale refunds are now marked 'pending_verification' (preserving the
+        // balance hold) instead of 'failed' (which would release the hold).
+        $this->assertSame(1, $result['requires_verification']);
         $this->assertSame(1, $result['total']);
 
         $stale = $this->db->fetchOne("SELECT status FROM op_refunds WHERE id = 8001");
         $this->assertNotNull($stale);
-        $this->assertSame('failed', $stale['status'], 'Stale pending refund must be auto-failed');
+        $this->assertSame('pending_verification', $stale['status'], 'Stale pending refund must be marked pending_verification');
 
         $recent = $this->db->fetchOne("SELECT status FROM op_refunds WHERE id = 8002");
         $this->assertNotNull($recent);
@@ -98,12 +101,12 @@ final class RefundReconciliationJobTest extends IntegrationTestCase
         $this->assertNotNull($completed);
         $this->assertSame('completed', $completed['status'], 'Terminal refunds must never be touched');
 
-        $this->assertCount(1, $fired, 'Notification event must fire once per auto-failed refund');
+        $this->assertCount(1, $fired, 'Notification event must fire once per marked refund');
 
         $auditRow = $this->db->fetchOne(
-            "SELECT id FROM op_audit_logs WHERE action = 'refund.reconciliation_failed' AND entity_id = 8001 ORDER BY id DESC LIMIT 1"
+            "SELECT id FROM op_audit_logs WHERE action = 'refund.requires_verification' AND entity_id = 8001 ORDER BY id DESC LIMIT 1"
         );
-        $this->assertNotNull($auditRow, 'Auto-fail must leave an audit trail');
+        $this->assertNotNull($auditRow, 'Auto-mark must leave an audit trail');
     }
 
     public function testIdempotentAcrossRuns(): void
@@ -113,7 +116,8 @@ final class RefundReconciliationJobTest extends IntegrationTestCase
         $first = $this->job->run();
         $second = $this->job->run();
 
-        $this->assertSame(1, $first['failed']);
-        $this->assertSame(0, $second['failed'], 'A second run must not re-fail or re-audit the same refund');
+        // Audit fix CRON-7: 'failed' key renamed to 'requires_verification'.
+        $this->assertSame(1, $first['requires_verification']);
+        $this->assertSame(0, $second['requires_verification'], 'A second run must not re-mark or re-audit the same refund');
     }
 }

--- a/tests/Integration/SmsGatewayAddonTest.php
+++ b/tests/Integration/SmsGatewayAddonTest.php
@@ -123,7 +123,7 @@ final class SmsGatewayAddonTest extends IntegrationTestCase
         $this->assertSame('+8801700000000', $log['recipient']);
         $this->assertSame('sms', $log['channel']);
 
-        $expectedMessage = 'Hi John Doe, invoice INV-2026-001 of BDT 1500.00 is ready. Due date: 2026-06-15. Pay here: https://localhost/invoice/invoice_test_token_123';
+        $expectedMessage = 'Hi John Doe, invoice INV-****-001 of BDT ****.00 is ready. Due date: ****-06-15. Pay here: https://localhost/invoice/invoice_test_token_123';
         $this->assertSame($expectedMessage, $log['body']);
     }
 
@@ -161,6 +161,12 @@ final class SmsGatewayAddonTest extends IntegrationTestCase
         $log = $logs[0];
         $this->assertSame('+8801800000000', $log['recipient']);
 
+        // CommunicationService::sendSms() intentionally redacts runs of 4+
+        // digits from the persisted log body so that admin viewers cannot
+        // read live OTPs / amounts / transaction ids. The raw message is
+        // still delivered to the recipient; only the stored log is masked.
+        // Note: '500' and '789' are only 3 digits long, so they are NOT
+        // redacted by the /\d{4,}/ regex.
         $expectedMessage = 'Thank you Jane Doe, your payment of BDT 500.00 (Trx ID: TXN-SUCCESS-789) was successful!';
         $this->assertSame($expectedMessage, $log['body']);
     }

--- a/tests/Middleware/RateLimiterMiddlewareTest.php
+++ b/tests/Middleware/RateLimiterMiddlewareTest.php
@@ -11,7 +11,9 @@ use OwnPay\Http\Response;
 use OwnPay\Middleware\RateLimiterMiddleware;
 use OwnPay\Repository\SettingsRepository;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class RateLimiterMiddlewareTest extends TestCase
 {
     private Container $container;

--- a/tests/Security/SecurityRemediationTest.php
+++ b/tests/Security/SecurityRemediationTest.php
@@ -421,6 +421,16 @@ PHP;
         // The mock must return an active 'mock-plugin' row so the listener
         // is allowed to run and the SQL-sandbox check actually fires.
         $db->method('fetchOne')->willReturn(['slug' => 'mock-plugin', 'status' => 'active']);
+        // When a prior test leaves $_SESSION['active_brand_id'] populated
+        // (common in full-suite runs — DeviceLiveStatusTest, etc. all seed
+        // it), BrandContext::getActiveBrandId() returns that stale id and
+        // isPluginActive takes the brand-scoped branch, which calls
+        // fetchAll() instead of fetchOne(). Without an active row from
+        // fetchAll() the plugin looks inactive, the filter is skipped, and
+        // the expected RuntimeException never fires. Returning an active
+        // row from fetchAll() makes the test robust against leftover
+        // session state without depending on test execution order.
+        $db->method('fetchAll')->willReturn([['slug' => 'mock-plugin', 'status' => 'active']]);
         $repo = new PluginRepository($db);
         $registry = new PluginRegistry($repo);
 

--- a/tests/Unit/PluginLoaderAdminMenuCapabilityTest.php
+++ b/tests/Unit/PluginLoaderAdminMenuCapabilityTest.php
@@ -13,7 +13,9 @@ use OwnPay\Plugin\PluginManifest;
 use OwnPay\Plugin\PluginRegistry;
 use OwnPay\Repository\PluginRepository;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PluginLoaderAdminMenuCapabilityTest extends TestCase
 {
     private function makeLoader(): array

--- a/tests/Unit/PluginRegistryHasCapabilityTest.php
+++ b/tests/Unit/PluginRegistryHasCapabilityTest.php
@@ -10,7 +10,9 @@ use OwnPay\Plugin\PluginInterface;
 use OwnPay\Plugin\PluginRegistry;
 use OwnPay\Repository\PluginRepository;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PluginRegistryHasCapabilityTest extends TestCase
 {
     private function makeRegistry(): PluginRegistry

--- a/tests/Unit/ThemeSecurityScannerTest.php
+++ b/tests/Unit/ThemeSecurityScannerTest.php
@@ -45,7 +45,15 @@ final class ThemeSecurityScannerTest extends TestCase
     private function writeTemplate(string $relativePath, string $content): void
     {
         $fullPath = $this->tmpDir . '/' . $relativePath;
-        mkdir(dirname($fullPath), 0777, true);
+        $dir = dirname($fullPath);
+        // Suppress "File exists" warning when the directory was already
+        // created by setUp() or a previous writeTemplate() call. mkdir()
+        // emits E_WARNING on the second call even though the directory
+        // already exists, which PHPUnit surfaces as a test-level warning.
+        // The third argument (`recursive`) lets us create nested parents.
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0777, true);
+        }
         file_put_contents($fullPath, $content);
     }
 

--- a/tests/Unit/UpdateServiceTest.php
+++ b/tests/Unit/UpdateServiceTest.php
@@ -19,6 +19,18 @@ class TestableUpdateService extends UpdateService
     public ?string $mockPackagePath = null;
     public bool $extractPackageCalled = false;
     public bool $runMigrationsCalled = false;
+
+    /**
+     * Substitutes the RSA public key used by UpdateService for signature
+     * verification. Used by testSuccessfulSignatureAndUpdate() to inject
+     * a test-generated key pair so the test does not depend on the
+     * production update_private_key.pem (which is intentionally not
+     * distributed with the repo).
+     */
+    public static function setUpdatePublicKey(string $pem): void
+    {
+        self::$updatePublicKey = $pem;
+    }
     public bool $clearCacheCalled = false;
     public bool $optimizeCalled = false;
 
@@ -243,14 +255,28 @@ class UpdateServiceTest extends TestCase
 
     public function testSuccessfulSignatureAndUpdate(): void
     {
-        $privateKeyPath = dirname(__DIR__, 2) . '/update_private_key.pem';
-        if (!file_exists($privateKeyPath)) {
-            $this->markTestSkipped('update_private_key.pem not found in project root.');
-        }
+        // Generate a temporary RSA key pair for this test run and inject
+        // the public key into UpdateService via the protected static
+        // $updatePublicKey property. This avoids the dependency on the
+        // production update_private_key.pem (which is intentionally not
+        // distributed with the repo) while still exercising the full
+        // sign → verify → extract → migrate → cache → optimize path.
+        $keyConfig = [
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ];
+        $keyResource = openssl_pkey_new($keyConfig);
+        $this->assertNotFalse($keyResource);
 
-        $privateKeyContent = file_get_contents($privateKeyPath);
+        $privateKeyContent = '';
+        $this->assertTrue(openssl_pkey_export($keyResource, $privateKeyContent));
         $privKeyResource = openssl_pkey_get_private($privateKeyContent);
         $this->assertNotFalse($privKeyResource);
+
+        $keyDetails = openssl_pkey_get_details($keyResource);
+        $this->assertIsArray($keyDetails);
+        $this->assertArrayHasKey('key', $keyDetails);
+        TestableUpdateService::setUpdatePublicKey($keyDetails['key']);
 
         $zipData = file_get_contents($this->tempZipPath);
         $this->assertTrue(openssl_sign($zipData, $signature, $privKeyResource, OPENSSL_ALGO_SHA256));

--- a/tests/Unit/WebhookDispatcherTest.php
+++ b/tests/Unit/WebhookDispatcherTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use OwnPay\Core\Database;
 use OwnPay\Event\EventManager;
 use OwnPay\Security\UrlValidator;
 use OwnPay\Service\System\Logger;
 use OwnPay\Service\Notification\WebhookDispatcher;
 
+#[AllowMockObjectsWithoutExpectations]
 class WebhookDispatcherTest extends TestCase
 {
     public function testHmacSigning(): void


### PR DESCRIPTION
## Summary

This PR addresses multiple PHPUnit test failures that surface when integration tests actually run against a live MySQL/MariaDB database (instead of being silently skipped when the DB is unreachable).

## Source fixes

- **`src/Service/Brand/BrandContext.php`**: Treat `activeBrandId === 0` as the canonical "All Brands" marker (set by `resolveFromRequest()` when `merchant_id=0` is passed via the request attribute, and by tests that explicitly assign `$_SESSION['active_brand_id'] = 0`). Without this, a request with `merchant_id=0` would be treated as brand-scoped, causing platform-owned resources (API keys, etc.) to be unreachable from the All Brands view.

- **`src/Service/Customer/ApiKeyService.php`**: Replace `date('c', $ts)` (ISO-8601 with `T` separator and timezone offset) with `gmdate('Y-m-d H:i:s', $ts)` when normalising key expiry timestamps. MariaDB 11.x with the default `STRICT_TRANS_TABLES` sql_mode rejects the ISO-8601 form with `SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value`.

- **`src/Service/System/TranslationService.php`**: When the on-disk JSON is missing but the language exists in the database (even with an empty translations payload — common right after `createLanguage()` copies `'{}'` for a brand-new locale), re-materialise the file. Without this, the next `setLocale()+trans()` cycle finds the file still missing and the "automatic file recovery" contract breaks.

- **`src/Update/UpdateService.php`**: Convert `UPDATE_PUBLIC_KEY` from a private const to a protected static string `$updatePublicKey` so the test harness can substitute a test-only key pair without depending on the production `update_private_key.pem` (which is intentionally not distributed with the repo).

- **`src/Repository/TransactionRepository.php`**: Include `'processing'` in the `findPendingByTrxId()` status filter so that retried transactions that have moved from `'pending'`/`'created'` into the `'processing'` state are still locatable for idempotency checks.

## Database changes

- **`database/schema.sql`**: Add `address_enc VARBINARY(1024)` and `status ENUM('active','deleted')` columns to `op_customers`, plus a composite index `idx_merchant_status` for filtered lookups. Required by audit fixes CUS-3 (address PII encryption) and CUS-4 (soft-delete row exclusion).
- **`database/migrations/005_add_customer_status_and_address.sql`**: Migration to apply the same schema changes to existing installations.
- **`database/seeds/roles.sql`**: Add new `brands.access_all` permission for the "All Brands" view (separate from `brands.manage` which is write-only).

## Test fixes

Updates 16 test files to align with the source fixes above (proper platform-merchant seeding, status-coverage, RSA-key-pair substitution for the update signing test, etc.).

## Test plan

- [ ] CI `PHPUnit Tests` job passes with zero errors, zero warnings, zero skips.
- [ ] PHPStan Analyse passes at level 9.
- [ ] PHP Lint passes.

## Notes

This PR is a work-in-progress toward the goal of `phpunit zero error, zero warning, zero Skip`. Further commits to this branch will follow up on remaining integration-test fixture gaps that currently cause errors when the DB is connected (these tests were previously silently skipped in CI because the DB credentials weren't propagated to the PHPUnit runner).